### PR TITLE
Add permissions to Release workflow for publishing docker packages

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -42,5 +42,7 @@ jobs:
     secrets: inherit
     permissions:
       id-token: write
+      contents: read
+      packages: write
     with:
       version: ${{needs.version.outputs.version}}


### PR DESCRIPTION
Migrating to PyPi trusted publishing in #399 required manually specifying permissions in #401. The latter PR inadvertently removed permissions for publishing docker packages