### PR TITLE
Add missing app label to model in plugins test

### DIFF
--- a/keystone_api/main/urls.py
+++ b/keystone_api/main/urls.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
-from django.urls import path, include
+from django.urls import include, path
 
 urlpatterns = [
     path('', lambda *args: HttpResponse(f"Keystone API Version {settings.VERSION}"), name='home'),

--- a/keystone_api/plugins/filter/tests/test_advanced_filter_backend.py
+++ b/keystone_api/plugins/filter/tests/test_advanced_filter_backend.py
@@ -5,11 +5,15 @@ from unittest.mock import Mock
 from django.db import models
 from django.test import TestCase
 from django_filters import FilterSet
+
 from plugins.filter import AdvancedFilterBackend, FactoryBuiltFilterSet
 
 
 class SampleModel(models.Model):
     """Sample database model for testing"""
+
+    class Meta:
+        app_label = 'plugins'
 
     bool_field = models.BooleanField()
     char_field = models.CharField(max_length=100)


### PR DESCRIPTION
This PR resolves an error that is raised when running the tests locally. 

```
RuntimeError: Model class keystone_api.plugins.filter.tests.test_advanced_filter_backend.SampleModel doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

CI does not have this problem due to the way it separates the tests into categories.