### PR TITLE
Allow request and application logs to have separate retention policies

### DIFF
--- a/docs/install/settings.md
+++ b/docs/install/settings.md
@@ -27,13 +27,14 @@ Improperly configured settings can introduce dangerous vulnerabilities and may d
 Keystone uses various static files and user content to facilitate operation.
 By default, these files are stored in subdirectories of the installed application directory (`<app>`).
 
-| Setting Name              | Default Value            | Description                                                                                       |
-|---------------------------|--------------------------|---------------------------------------------------------------------------------------------------|
-| `CONFIG_TIMEZONE`         | `UTC`                    | The application timezone.                                                                         |
-| `CONFIG_STATIC_DIR`       | `<app>/static_files`     | Where to store internal static files required by the application.                                 |
-| `CONFIG_UPLOAD_DIR`       | `<app>/upload_files`     | Where to store file data uploaded by users.                                                       |
-| `CONFIG_LOG_RETENTION`    | 30 days                  | How long to store log records in seconds. Set to 0 to keep all records.                           |
-| `CONFIG_LOG_LEVEL`        | `WARNING`                | Only record logs above this level (`CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `NOTSET`). |
+| Setting Name               | Default Value        | Description                                                                                                 |
+|----------------------------|----------------------|-------------------------------------------------------------------------------------------------------------|
+| `CONFIG_TIMEZONE`          | `UTC`                | The timezone to use when rendering date/time values.                                                        |
+| `CONFIG_STATIC_DIR`        | `<app>/static_files` | Where to store internal static files required by the application.                                           |
+| `CONFIG_UPLOAD_DIR`        | `<app>/upload_files` | Where to store file data uploaded by users.                                                                 |
+| `CONFIG_LOG_LEVEL`         | `WARNING`            | Only record application logs above this level (accepts `CRITICAL`, `ERROR`, `WARNING`, `INFO`, or `DEBUG`). |
+| `CONFIG_LOG_RETENTION`     | `2592000` (30 days)  | How long to store application logs in seconds. Set to 0 to keep all records.                                |
+| `CONFIG_REQUEST_RETENTION` | `2592000` (30 days)  | How long to store request logs in seconds. Set to 0 to keep all records.                                    |
 
 ## API Throttling
 

--- a/keystone_api/apps/logging/tasks.py
+++ b/keystone_api/apps/logging/tasks.py
@@ -15,12 +15,13 @@ from .models import *
 
 
 @shared_task()
-def rotate_log_files() -> None:
-    """Delete old log files."""
+def clear_log_files() -> None:
+    """Delete request and application logs according to retention policies set in application settings."""
 
-    if settings.LOG_RECORD_ROTATION == 0:
-        return
+    if settings.CONFIG_LOG_RETENTION > 0:
+        max_app_log_age = timezone.now() - timedelta(seconds=settings.CONFIG_LOG_RETENTION)
+        AppLog.objects.filter(time__lt=max_app_log_age).delete()
 
-    max_record_age = timezone.now() - timedelta(seconds=settings.LOG_RECORD_ROTATION)
-    AppLog.objects.filter(time__lt=max_record_age).delete()
-    RequestLog.objects.filter(time__lt=max_record_age).delete()
+    if settings.CONFIG_REQUEST_RETENTION > 0:
+        max_request_log_age = timezone.now() - timedelta(seconds=settings.CONFIG_REQUEST_RETENTION)
+        RequestLog.objects.filter(time__lt=max_request_log_age).delete()

--- a/keystone_api/apps/logging/tests/test_tasks/test_rotate_log_files.py
+++ b/keystone_api/apps/logging/tests/test_tasks/test_rotate_log_files.py
@@ -7,7 +7,7 @@ from django.test import override_settings, TestCase
 from django.utils.timezone import now
 
 from apps.logging.models import AppLog, RequestLog
-from apps.logging.tasks import rotate_log_files
+from apps.logging.tasks import clear_log_files
 
 
 class LogFileDeletion(TestCase):
@@ -61,7 +61,7 @@ class LogFileDeletion(TestCase):
         self.assertEqual(2, RequestLog.objects.count())
 
         # Run rotation
-        rotate_log_files()
+        clear_log_files()
 
         # Assert only the newer records remain
         self.assertEqual(1, AppLog.objects.count())
@@ -73,6 +73,6 @@ class LogFileDeletion(TestCase):
 
         self.create_dummy_records(now())
 
-        rotate_log_files()
+        clear_log_files()
         self.assertEqual(1, AppLog.objects.count())
         self.assertEqual(1, RequestLog.objects.count())

--- a/keystone_api/apps/logging/tests/test_tasks/test_rotate_log_files.py
+++ b/keystone_api/apps/logging/tests/test_tasks/test_rotate_log_files.py
@@ -37,9 +37,10 @@ class LogFileDeletion(TestCase):
             time=timestamp
         )
 
-    @override_settings(LOG_RECORD_ROTATION=4)
+    @override_settings(CONFIG_LOG_RETENTION=4)
+    @override_settings(CONFIG_REQUEST_RETENTION=4)
     @patch('django.utils.timezone.now')
-    def test_log_files_rotated(self, mock_now: Mock) -> None:
+    def test_log_files_deleted(self, mock_now: Mock) -> None:
         """Test expired log files are deleted."""
 
         # Mock the current time
@@ -67,9 +68,10 @@ class LogFileDeletion(TestCase):
         self.assertEqual(1, AppLog.objects.count())
         self.assertEqual(1, RequestLog.objects.count())
 
-    @override_settings(LOG_RECORD_ROTATION=0)
-    def test_rotation_disabled(self) -> None:
-        """Test log files are not deleted when rotation is disabled."""
+    @override_settings(CONFIG_LOG_RETENTION=0)
+    @override_settings(CONFIG_REQUEST_RETENTION=0)
+    def test_deletion_disabled(self) -> None:
+        """Test log files are not deleted when log clearing is disabled."""
 
         self.create_dummy_records(now())
 

--- a/keystone_api/apps/scheduler/celery.py
+++ b/keystone_api/apps/scheduler/celery.py
@@ -19,8 +19,8 @@ celery_app.conf.beat_schedule = {
         'schedule': crontab(minute='0'),
         'description': 'This task synchronizes user data against LDAP. This task does nothing if LDAP is disabled.'
     },
-    'apps.logging.tasks.rotate_log_files': {
-        'task': 'apps.logging.tasks.rotate_log_files',
+    'apps.logging.tasks.clear_log_files': {
+        'task': 'apps.logging.tasks.clear_log_files',
         'schedule': crontab(hour='0', minute='0'),
         'description': 'This task deletes old log entries according to application settings.'
     },

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -30,17 +30,23 @@ FIXTURE_DIRS = [BASE_DIR / 'tests' / 'fixtures']
 SECRET_KEY = os.environ.get('SECURE_SECRET_KEY', get_random_secret_key())
 ALLOWED_HOSTS = env.list("SECURE_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
-_SECURE_SESSION_TOKENS = env.bool("SECURE_SESSION_TOKENS", False)
-SESSION_COOKIE_SECURE = _SECURE_SESSION_TOKENS
-CSRF_COOKIE_SECURE = _SECURE_SESSION_TOKENS
+_SECURE_SSL_TOKENS = env.bool("SECURE_SSL_TOKENS", False)
+SESSION_COOKIE_SECURE = _SECURE_SSL_TOKENS
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_AGE = env.int("SECURE_SESSION_AGE", 1209600)  # 2 weeks
+
 CSRF_TRUSTED_ORIGINS = env.list("SECURE_CSRF_ORIGINS", default=[])
+CSRF_COOKIE_SECURE = _SECURE_SSL_TOKENS
+CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_SAMESITE = "Lax"
 
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", False)
 SECURE_HSTS_PRELOAD = env.bool("SECURE_HSTS_PRELOAD", False)
 SECURE_HSTS_SECONDS = env.int("SECURE_HSTS_SECONDS", 0)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_SUBDOMAINS", False)
 
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=[])
 
 # App Configuration
 
@@ -50,6 +56,7 @@ SITE_ID = 1
 
 INSTALLED_APPS = [
     'jazzmin',
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -65,7 +72,8 @@ INSTALLED_APPS = [
     'health_check.contrib.celery_ping',
     'health_check.contrib.redis',
     'rest_framework',
-    'rest_framework_simplejwt.token_blacklist',
+    'rest_framework.authtoken',
+    'dj_rest_auth',
     'django_celery_beat',
     'django_celery_results',
     'django_filters',
@@ -86,18 +94,18 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'apps.logging.middleware.LogRequestMiddleware',
 ]
 
 TEMPLATES = [
-    {  # The default backend rquired by Django builtins (e.g., the admin)
+    {  # The default backend required by Django builtins (e.g., the admin)
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
         'OPTIONS': {
@@ -139,9 +147,6 @@ JAZZMIN_SETTINGS = {
 # REST API settings
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
-    ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated'
     ],
@@ -257,12 +262,6 @@ AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
 ]
 
-SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=env.int('SECURE_ACCESS_TOKEN_LIFETIME', 5 * 60)),
-    'REFRESH_TOKEN_LIFETIME': timedelta(seconds=env.int('SECURE_REFRESH_TOKEN_LIFETIME', 24 * 60 * 60)),
-    'UPDATE_LAST_LOGIN': True
-}
-
 # Static file handling (CSS, JavaScript, Images)
 
 STATIC_URL = 'static/'
@@ -282,7 +281,9 @@ TIME_ZONE = env.str('CONFIG_TIMEZONE', 'UTC')
 
 # Logging
 
-LOG_RECORD_ROTATION = env.int('CONFIG_LOG_RETENTION', timedelta(days=30).total_seconds())
+CONFIG_LOG_RETENTION = env.int('CONFIG_LOG_RETENTION', timedelta(days=30).total_seconds())
+CONFIG_REQUEST_RETENTION = env.int('CONFIG_REQUEST_RETENTION', timedelta(days=30).total_seconds())
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -30,23 +30,17 @@ FIXTURE_DIRS = [BASE_DIR / 'tests' / 'fixtures']
 SECRET_KEY = os.environ.get('SECURE_SECRET_KEY', get_random_secret_key())
 ALLOWED_HOSTS = env.list("SECURE_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
-_SECURE_SSL_TOKENS = env.bool("SECURE_SSL_TOKENS", False)
-SESSION_COOKIE_SECURE = _SECURE_SSL_TOKENS
-SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SAMESITE = "Lax"
-SESSION_COOKIE_AGE = env.int("SECURE_SESSION_AGE", 1209600)  # 2 weeks
-
+_SECURE_SESSION_TOKENS = env.bool("SECURE_SESSION_TOKENS", False)
+SESSION_COOKIE_SECURE = _SECURE_SESSION_TOKENS
+CSRF_COOKIE_SECURE = _SECURE_SESSION_TOKENS
 CSRF_TRUSTED_ORIGINS = env.list("SECURE_CSRF_ORIGINS", default=[])
-CSRF_COOKIE_SECURE = _SECURE_SSL_TOKENS
-CSRF_COOKIE_HTTPONLY = False
-CSRF_COOKIE_SAMESITE = "Lax"
 
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", False)
 SECURE_HSTS_PRELOAD = env.bool("SECURE_HSTS_PRELOAD", False)
 SECURE_HSTS_SECONDS = env.int("SECURE_HSTS_SECONDS", 0)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_SUBDOMAINS", False)
 
-CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=[])
+CORS_ORIGIN_ALLOW_ALL = True
 
 # App Configuration
 
@@ -56,7 +50,6 @@ SITE_ID = 1
 
 INSTALLED_APPS = [
     'jazzmin',
-    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -72,8 +65,7 @@ INSTALLED_APPS = [
     'health_check.contrib.celery_ping',
     'health_check.contrib.redis',
     'rest_framework',
-    'rest_framework.authtoken',
-    'dj_rest_auth',
+    'rest_framework_simplejwt.token_blacklist',
     'django_celery_beat',
     'django_celery_results',
     'django_filters',
@@ -94,12 +86,12 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'apps.logging.middleware.LogRequestMiddleware',
 ]
@@ -147,6 +139,9 @@ JAZZMIN_SETTINGS = {
 # REST API settings
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated'
     ],
@@ -261,6 +256,12 @@ AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
     {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
 ]
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=env.int('SECURE_ACCESS_TOKEN_LIFETIME', 5 * 60)),
+    'REFRESH_TOKEN_LIFETIME': timedelta(seconds=env.int('SECURE_REFRESH_TOKEN_LIFETIME', 24 * 60 * 60)),
+    'UPDATE_LAST_LOGIN': True
+}
 
 # Static file handling (CSS, JavaScript, Images)
 


### PR DESCRIPTION
Replaces the `CONFIG_LOG_RETENTION` setting with the new `CONFIG_LOG_RETENTION` and `CONFIG_REQUEST_RETENTION` settings. This allows application logs and request logs to have separate retention policies.