### PR TITLE
Revert Django to 5.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keystone-api = "keystone_api.manage:main"
 [tool.poetry.dependencies]
 python = "^3.11"
 coverage = "*"
-django = "5.1"
+django = "5.0.8"
 django-celery-beat = "2.7.0"
 django-celery-results = "2.5.1"
 django-cors-headers = "4.4.0"


### PR DESCRIPTION
Running into a 500 error in the admin due to the following:

https://github.com/farridav/django-jazzmin/issues/593