### PR TITLE
Fixes system check error when ldap is not installed

### DIFF
--- a/keystone_api/apps/users/tasks.py
+++ b/keystone_api/apps/users/tasks.py
@@ -7,12 +7,12 @@ application database.
 
 from celery import shared_task
 from django.conf import settings
-from django_auth_ldap.backend import LDAPBackend
 from tqdm import tqdm
 
 # Optional dependencies
 try:
     import ldap
+    from django_auth_ldap.backend import LDAPBackend
 
 except ImportError:  # pragma: nocover
     pass


### PR DESCRIPTION
One of the LDAP imports was not wrapped correctly, causing the new system check from #419 to fail.