### PR TITLE
Override --version in CLI to display app version

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -184,7 +184,7 @@ REST_FRAMEWORK = {
 # Customize the generation of OpenAPI specifications
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Keystone API',
+    'TITLE': f'Keystone API',
     'DESCRIPTION': SUMMARY,
     'VERSION': VERSION,
     'SERVE_INCLUDE_SCHEMA': False,

--- a/keystone_api/manage.py
+++ b/keystone_api/manage.py
@@ -12,6 +12,11 @@ def main() -> None:  # pragma: nocover
     """Parse the commandline and run administrative tasks."""
 
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'keystone_api.main.settings')
+    if '--version' in sys.argv:
+        from django.conf import settings
+        print(settings.VERSION)
+        sys.exit(0)
+
     execute_from_command_line(sys.argv)
 
 


### PR DESCRIPTION
Modifies `manage.py` so the `--version` CLI option displays the keystone version and not the django version. The original behavior was confusing as `keystone-api --version` would not actually display the version of Keystone API.