### PR TITLE
Add `ordering` argument to query params

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -125,6 +125,12 @@ paths:
         name: id__lte
         schema:
           type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       - in: query
         name: request
         schema:
@@ -435,6 +441,12 @@ paths:
           type: boolean
       - in: query
         name: name__startswith
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       tags:
@@ -771,6 +783,12 @@ paths:
         name: id__lte
         schema:
           type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       - in: query
         name: status
         schema:
@@ -1190,6 +1208,12 @@ paths:
         name: last_modified__year
         schema:
           type: number
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       - in: query
         name: private_comments
         schema:
@@ -1774,6 +1798,12 @@ paths:
         name: name__startswith
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       - in: query
         name: pathname
         schema:
@@ -2092,6 +2122,12 @@ paths:
           type: boolean
       - in: query
         name: method__startswith
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       - in: query
@@ -2546,6 +2582,12 @@ paths:
           type: boolean
       - in: query
         name: meta__startswith
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       - in: query
@@ -3086,6 +3128,12 @@ paths:
         name: id__lte
         schema:
           type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       - in: query
         name: start_date
         schema:
@@ -3524,6 +3572,12 @@ paths:
         name: journal__startswith
         schema:
           type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       - in: query
         name: team
         schema:
@@ -3801,6 +3855,12 @@ paths:
           type: boolean
       - in: query
         name: name__startswith
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       tags:
@@ -4314,6 +4374,12 @@ paths:
           type: boolean
       - in: query
         name: last_name__startswith
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
         schema:
           type: string
       - in: query

--- a/docs/api/filtering.md
+++ b/docs/api/filtering.md
@@ -1,18 +1,40 @@
-# Filtering Requests
+# Structuring Queries
 
-When querying data from an API endpoint, the returned records can be filtered using URL parameters.
+Keystone API uses query parameters to sort and filter records in API responses.
+Since these operations are applied at the database level, using query parameters is often more performant than processing data client side.
+
+## Sorting Requests
+
+The `ordering` parameter is used to sort records by one or more fields.
+
+```
+.../endpoint/?ordering=field1
+.../endpoint/?ordering=field1,field2
+```
+
+To sort in descending order, a hyphen is prefixed to the field name.
+In the following example, `field1` is sorted in ascending order and `field2` in descending order.
+
+```bash
+.../endpoint/?ordering=field1,-field2
+```
+
+
+## Filtering Requests
+
+Query parameters provide basic support for filtering records by the value of their fields.
 In the following example, returned records are limited to those where the `example` field equals `100`:
 
 ```
-my.domain.com/endpoint?example=100
+.../endpoint?example=100
 ```
 
-More advanced filtering is achieved by adding query filters.
-Query filters are specified using a double underscre (`__`) followed by filter expression.
+More advanced filtering is achieved by adding filters.
+Query filters are specified using a double underscore (`__`) followed by a filter expression.
 For example, the following API call will return records when the `example` field is greater than `50` but less than `150`:
 
 ```
-my.domain.com/endpoint?example__gt=50&example_lt=150
+.../endpoint?example__gt=50&example_lt=150
 ```
 
 Available query filters are summarized in the tables below.

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -178,6 +178,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_FILTER_BACKENDS': (
         'plugins.filter.AdvancedFilterBackend',
+        'rest_framework.filters.OrderingFilter'
+
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }


### PR DESCRIPTION
Adds support for ordering query results by one or more fields in ascending or descending order.