### PR TITLE
Shorten default log retention to 1 week

### DIFF
--- a/docs/install/settings.md
+++ b/docs/install/settings.md
@@ -26,13 +26,13 @@ Improperly configured settings can introduce dangerous vulnerabilities and may d
 
 ### CORS/CSRF
 
-| Setting Name             | Default Value                                                                                                                                         | Description                                                            |
-|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| `SECURE_ALLOWED_HOSTS`   | <code>localhost</code><br><code>127.0.0.1</code>                                                                                                                                | Comma-separated list of accepted host/domain names (without protocol). |
+| Setting Name             | Default Value                                                                                                                                          | Description                                                            |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| `SECURE_ALLOWED_HOSTS`   | <code>localhost</code><br><code>127.0.0.1</code>                                                                                                       | Comma-separated list of accepted host/domain names (without protocol). |
 | `SECURE_ALLOWED_ORIGINS` | <code>http://localhost:4200</code><br><code>https://localhost:4200</code><br><code>http://127.0.0.1:4200</code><br><code>https://127.0.0.1:4200</code> | Comma-separated list of accepted CORS origin domains (with protocol).  |
 | `SECURE_CSRF_ORIGINS`    | <code>http://localhost:4200</code><br><code>https://localhost:4200</code><br><code>http://127.0.0.1:4200</code><br><code>https://127.0.0.1:4200</code> | Comma-separated list of accepted CSRF origin domains (with protocol).  |
-| `SECURE_SSL_TOKENS`      | `False`                                                                                                                                               | Only issue session/CSRF tokens over secure connections.                |
-| `SECURE_SESSION_AGE`     | `1209600` (2 weeks)                                                                                                                                   | Number of seconds before session tokens expire.                        |
+| `SECURE_SSL_TOKENS`      | `False`                                                                                                                                                | Only issue session/CSRF tokens over secure connections.                |
+| `SECURE_SESSION_AGE`     | `1209600` (2 weeks)                                                                                                                                    | Number of seconds before session tokens expire.                        |
 
 ## General Configuration
 
@@ -45,8 +45,8 @@ By default, these files are stored in subdirectories of the installed applicatio
 | `CONFIG_STATIC_DIR`        | `<app>/static_files` | Where to store internal static files required by the application.                                           |
 | `CONFIG_UPLOAD_DIR`        | `<app>/upload_files` | Where to store file data uploaded by users.                                                                 |
 | `CONFIG_LOG_LEVEL`         | `WARNING`            | Only record application logs above this level (accepts `CRITICAL`, `ERROR`, `WARNING`, `INFO`, or `DEBUG`). |
-| `CONFIG_LOG_RETENTION`     | `2592000` (30 days)  | How long to store application logs in seconds. Set to 0 to keep all records.                                |
-| `CONFIG_REQUEST_RETENTION` | `2592000` (30 days)  | How long to store request logs in seconds. Set to 0 to keep all records.                                    |
+| `CONFIG_LOG_RETENTION`     | `604800` (1 week)    | How long to store application logs in seconds. Set to 0 to keep all records.                                |
+| `CONFIG_REQUEST_RETENTION` | `604800` (1 week)    | How long to store request logs in seconds. Set to 0 to keep all records.                                    |
 
 ## API Throttling
 

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -299,8 +299,8 @@ TIME_ZONE = env.str('CONFIG_TIMEZONE', 'UTC')
 
 # Logging
 
-CONFIG_LOG_RETENTION = env.int('CONFIG_LOG_RETENTION', timedelta(days=30).total_seconds())
-CONFIG_REQUEST_RETENTION = env.int('CONFIG_REQUEST_RETENTION', timedelta(days=30).total_seconds())
+CONFIG_LOG_RETENTION = env.int('CONFIG_LOG_RETENTION', timedelta(days=14).total_seconds())
+CONFIG_REQUEST_RETENTION = env.int('CONFIG_REQUEST_RETENTION', timedelta(days=14).total_seconds())
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Having spent some time working with the logs, 4 weeks feels like an excessive default. The default value should be short enough to handle problems stemming from the last few days. Holding on to anything longer is the decision of the administrator.