### PR TITLE
Hides auth tokens in admin panel

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -148,7 +148,7 @@ JAZZMIN_SETTINGS = {
     "site_title": "Keystone",
     "site_header": "Keystone",
     "site_brand": "Keystone",
-    "hide_apps": ["sites", "auth", "token_blacklist"],
+    "hide_apps": ["sites", "auth", "authtoken", "token_blacklist"],
     "order_with_respect_to": [
         "users",
         "allocations",


### PR DESCRIPTION
Including the auth tokens in the admin panel was an unintentional consequence of switching to the new authentication system.