### PR TITLE
Fix missing uniqueness constraint in DB migration

### DIFF
--- a/keystone_api/apps/users/migrations/0009_team_teammembership_team_users_delete_researchgroup.py
+++ b/keystone_api/apps/users/migrations/0009_team_teammembership_team_users_delete_researchgroup.py
@@ -1,6 +1,8 @@
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models, connection
+from django.db.models import UniqueConstraint
+
 
 def insert_team_memberships(apps, schema_editor):
     if connection.vendor == 'postgresql':
@@ -66,7 +68,9 @@ class Migration(migrations.Migration):
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
-                'unique_together': {('user', 'team')},
+                'constraints': [
+                    UniqueConstraint(fields=['user', 'team'], name='unique_user_team')
+                ],
             },
         ),
 

--- a/keystone_api/apps/users/models.py
+++ b/keystone_api/apps/users/models.py
@@ -15,6 +15,7 @@ from django.contrib.auth import models as auth_models
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.files.base import ContentFile
 from django.db import models
+from django.db.models import UniqueConstraint
 from django.utils import timezone
 from PIL import Image
 
@@ -29,7 +30,9 @@ class TeamMembership(models.Model):
     class Meta:
         """Database model settings."""
 
-        unique_together = ('user', 'team')
+        constraints = [
+            UniqueConstraint(fields=['user', 'team'], name='unique_user_team')
+        ]
 
     class Role(models.TextChoices):
         """Define choices for the `role` field.


### PR DESCRIPTION
The team membership model and it's associated migration was using an outdated Django mechanism for defining uniqueness constraints. This resulted in the constrain not being applied correctly causing the Postgres migration to fail.