### PR TITLE
Dissable attestations when publishing to PyPI

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -85,6 +85,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
+          attestations: false
 
   trigger-docs:
     name: Trigger Docs


### PR DESCRIPTION
Support for PyPI attestations is still buggy and fails in CI. Recent changes to CI dependencies enable it by default. This PR manually disables them.