### PR TITLE
Removes headers from recomended nginx setup

### DIFF
--- a/docs/install/python.md
+++ b/docs/install/python.md
@@ -222,11 +222,6 @@ server {
     ssl_certificate_key /etc/pki/tls/private/keystone.key;
 
     location / {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        
         proxy_pass http://unix:/run/gunicorn.sock;
     }
 


### PR DESCRIPTION
The recommended headers conflicted with default application CSRF settings.