### PR TITLE
Removes MEDIA_URL prefix from returned media paths

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -288,7 +288,6 @@ STATIC_URL = 'static/'
 STATIC_ROOT = Path(env.path('CONFIG_STATIC_DIR', BASE_DIR / 'static_files'))
 STATIC_ROOT.mkdir(parents=True, exist_ok=True)
 
-MEDIA_URL = 'media/'
 MEDIA_ROOT = Path(env.path('CONFIG_UPLOAD_DIR', BASE_DIR / 'media'))
 MEDIA_ROOT.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
The API was including a `/media/` prefix when returning paths for media files. This was conflicting with the `/media/` location defined in the NGINX proxy and breaking media file serving. The fix was to remove the prefix by dropping the MEDIA_URL setting.