### PR TITLE
Fixes CI bug where app version is not set in ARM container image

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
+
+      - name: Set package version
+        run: poetry version "${{ inputs.version }}"
+
       - name: Fetch image artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The CI failing to set the application version correctly when building non-x86 images. The x86 image was fine because it is built separately at the beginning of the pipeline for use in tests. All other platforms are only built when publishing the image.