### PR TITLE
Mocks health check runs to improve test performance

### DIFF
--- a/keystone_api/tests/health/test.py
+++ b/keystone_api/tests/health/test.py
@@ -1,23 +1,27 @@
 """Function tests for the `/health/` endpoint."""
 
+from unittest.mock import Mock, patch
+
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
 from apps.users.models import User
+from tests.utils import CustomAsserts
 
 
-class EndpointPermissions(APITransactionTestCase):
+@patch('health_check.backends.BaseHealthCheckBackend.run_check', return_value=None)
+class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     """Test endpoint user permissions.
 
     Endpoint permissions are tested against the following matrix of HTTP responses.
-    The returned response value depends on the result of the system helath check.
-    A 200/500 response is used when health checks pass/fail.
+    In production, the returned response value depends on the result of the system health check.
+    However, these tests mock the tests to always pass, ensuring a 200 response code.
 
-    | User Status                | GET     | HEAD     | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
-    |----------------------------|---------|----------|---------|------|-----|-------|--------|-------|
-    | Unauthenticated User       | 200/500 | 200/500  | 200/500 | 405  | 405 | 405   | 405    | 405   |
-    | Authenticated User         | 200/500 | 200/500  | 200/500 | 405  | 405 | 405   | 405    | 405   |
-    | Staff User                 | 200/500 | 200/500  | 200/500 | 405  | 405 | 405   | 405    | 405   |
+    | User Status                | GET  | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
+    |----------------------------|------|------|---------|------|-----|-------|--------|-------|
+    | Unauthenticated User       | 200 | 200   | 200     | 405  | 405 | 405   | 405    | 405   |
+    | Authenticated User         | 200 | 200   | 200     | 405  | 405 | 405   | 405    | 405   |
+    | Staff User                 | 200 | 200   | 200     | 405  | 405 | 405   | 405    | 405   |
     """
 
     endpoint = '/health/'
@@ -30,32 +34,49 @@ class EndpointPermissions(APITransactionTestCase):
         self.staff_user = User.objects.get(username='staff_user')
         self.generic_user = User.objects.get(username='generic_user')
 
-    def assert_read_only_responses(self) -> None:
-        """Assert the currently authenticated user has read only permissions."""
-
-        self.assertIn(self.client.get(self.endpoint).status_code, self.valid_responses)
-        self.assertIn(self.client.head(self.endpoint).status_code, self.valid_responses)
-        self.assertIn(self.client.options(self.endpoint).status_code, self.valid_responses)
-
-        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-    def test_unauthenticated_user_permissions(self) -> None:
+    def test_unauthenticated_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test unauthenticated users have read-only permissions."""
 
-        self.assert_read_only_responses()
+        self.assert_http_responses(
+            self.endpoint,
+            get=status.HTTP_200_OK,
+            head=status.HTTP_200_OK,
+            options=status.HTTP_200_OK,
+            post=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put=status.HTTP_405_METHOD_NOT_ALLOWED,
+            patch=status.HTTP_405_METHOD_NOT_ALLOWED,
+            delete=status.HTTP_405_METHOD_NOT_ALLOWED,
+            trace=status.HTTP_405_METHOD_NOT_ALLOWED,
+        )
 
-    def test_authenticated_user_permissions(self) -> None:
+    def test_authenticated_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test authenticated users have read-only permissions."""
 
         self.client.force_authenticate(user=self.generic_user)
-        self.assert_read_only_responses()
+        self.assert_http_responses(
+            self.endpoint,
+            get=status.HTTP_200_OK,
+            head=status.HTTP_200_OK,
+            options=status.HTTP_200_OK,
+            post=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put=status.HTTP_405_METHOD_NOT_ALLOWED,
+            patch=status.HTTP_405_METHOD_NOT_ALLOWED,
+            delete=status.HTTP_405_METHOD_NOT_ALLOWED,
+            trace=status.HTTP_405_METHOD_NOT_ALLOWED,
+        )
 
-    def test_staff_user_permissions(self) -> None:
+    def test_staff_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test staff users have read-only permissions."""
 
         self.client.force_authenticate(user=self.staff_user)
-        self.assert_read_only_responses()
+        self.assert_http_responses(
+            self.endpoint,
+            get=status.HTTP_200_OK,
+            head=status.HTTP_200_OK,
+            options=status.HTTP_200_OK,
+            post=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put=status.HTTP_405_METHOD_NOT_ALLOWED,
+            patch=status.HTTP_405_METHOD_NOT_ALLOWED,
+            delete=status.HTTP_405_METHOD_NOT_ALLOWED,
+            trace=status.HTTP_405_METHOD_NOT_ALLOWED,
+        )

--- a/keystone_api/tests/health/test_json.py
+++ b/keystone_api/tests/health/test_json.py
@@ -1,5 +1,7 @@
 """Function tests for the `/health/json/` endpoint."""
 
+from unittest.mock import Mock, patch
+
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
@@ -7,6 +9,7 @@ from apps.users.models import User
 from tests.utils import CustomAsserts
 
 
+@patch('health_check.backends.BaseHealthCheckBackend.run_check', return_value=None)
 class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     """Test endpoint user permissions.
 
@@ -28,7 +31,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
         self.staff_user = User.objects.get(username='staff_user')
         self.generic_user = User.objects.get(username='generic_user')
 
-    def test_unauthenticated_user_permissions(self) -> None:
+    def test_unauthenticated_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test unauthenticated users have read-only permissions."""
 
         self.assert_http_responses(
@@ -43,7 +46,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
             trace=status.HTTP_405_METHOD_NOT_ALLOWED,
         )
 
-    def test_authenticated_user_permissions(self) -> None:
+    def test_authenticated_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test authenticated users have read-only permissions."""
 
         self.client.force_authenticate(user=self.generic_user)
@@ -59,7 +62,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
             trace=status.HTTP_405_METHOD_NOT_ALLOWED,
         )
 
-    def test_staff_user_permissions(self) -> None:
+    def test_staff_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test staff users have read-only permissions."""
 
         self.client.force_authenticate(user=self.staff_user)

--- a/keystone_api/tests/health/test_prom.py
+++ b/keystone_api/tests/health/test_prom.py
@@ -1,5 +1,7 @@
 """Function tests for the `/health/prom/` endpoint."""
 
+from unittest.mock import Mock, patch
+
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
@@ -7,6 +9,7 @@ from apps.users.models import User
 from tests.utils import CustomAsserts
 
 
+@patch('health_check.backends.BaseHealthCheckBackend.run_check', return_value=None)
 class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     """Test endpoint user permissions.
 
@@ -29,7 +32,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
         self.staff_user = User.objects.get(username='staff_user')
         self.generic_user = User.objects.get(username='generic_user')
 
-    def test_unauthenticated_user_permissions(self) -> None:
+    def test_unauthenticated_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test unauthenticated users have read-only permissions."""
 
         self.assert_http_responses(
@@ -44,7 +47,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
             trace=status.HTTP_405_METHOD_NOT_ALLOWED,
         )
 
-    def test_authenticated_user_permissions(self) -> None:
+    def test_authenticated_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test authenticated users have read-only permissions."""
 
         self.client.force_authenticate(user=self.generic_user)
@@ -60,7 +63,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
             trace=status.HTTP_405_METHOD_NOT_ALLOWED,
         )
 
-    def test_staff_user_permissions(self) -> None:
+    def test_staff_user_permissions(self, _mock_run_check: Mock) -> None:
         """Test staff users have read-only permissions."""
 
         self.client.force_authenticate(user=self.staff_user)


### PR DESCRIPTION
Function tests for the health check endpoints take about 12 seconds each (12 x 9 = 108 total) to run (values measured on my personal laptop). Not only is this annoying, but the tests leverage threading which is causing problems with the Sqlite database used during testing. This PR should address both issues by mocking the results of the individual health checks so they never run.