### PR TITLE
Bumps authenticated request throttling to 300/min

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -173,7 +173,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_THROTTLE_RATES': {
         'anon': env.str('API_THROTTLE_ANON', '120/min'),
-        'user': env.str('API_THROTTLE_USER', '240/min')
+        'user': env.str('API_THROTTLE_USER', '300/min')
     },
     'DEFAULT_RENDERER_CLASSES': [
         'rest_framework.renderers.JSONRenderer',


### PR DESCRIPTION
The test suite is starting to push the rate throttling. A simple fix is to bump the limit. 300/min is about 5/sec, which "feels" reasonable for authenticated users.