### PR TITLE
Mark team.is_active field as required in API

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -6460,11 +6460,11 @@ components:
           items:
             $ref: '#/components/schemas/UserRole'
           default: []
+        is_active:
+          type: boolean
         name:
           type: string
           maxLength: 255
-        is_active:
-          type: boolean
         users:
           type: array
           items:
@@ -6826,11 +6826,11 @@ components:
           items:
             $ref: '#/components/schemas/UserRole'
           default: []
+        is_active:
+          type: boolean
         name:
           type: string
           maxLength: 255
-        is_active:
-          type: boolean
         users:
           type: array
           items:
@@ -6838,6 +6838,7 @@ components:
           readOnly: true
       required:
       - id
+      - is_active
       - name
       - users
     TeamRole:

--- a/keystone_api/apps/users/serializers.py
+++ b/keystone_api/apps/users/serializers.py
@@ -86,6 +86,7 @@ class TeamSerializer(serializers.ModelSerializer):
     """Object serializer for the `Team` model."""
 
     membership = UserRoleSerializer(many=True, read_only=False, required=False, default=[])
+    is_active = serializers.BooleanField(required=True)
 
     class Meta:
         """Serializer settings."""


### PR DESCRIPTION
The is_active field is always included in read requests but was optional in write operations (post and put). This PR marks the field as required everywhere, which eliminates the need for annoying manipulations when typing front end services.