### PR TITLE
Add file upload in allocations apps

### DIFF
--- a/keystone_api/apps/allocations/serializers.py
+++ b/keystone_api/apps/allocations/serializers.py
@@ -98,7 +98,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
 
     _request = AllocationRequestSummarySerializer(source='request', read_only=True)
     path = serializers.FileField(use_url=False, read_only=True)
-
+   
     class Meta:
         """Serializer settings."""
 
@@ -129,3 +129,9 @@ class CommentSerializer(serializers.ModelSerializer):
 
         model = Comment
         fields = '__all__'
+
+class FileUploadSerializer(serializers.Serializer):
+    file = serializers.FileField()
+    class Meta:
+        fields = ['file_uploaded']
+        

--- a/keystone_api/apps/allocations/urls.py
+++ b/keystone_api/apps/allocations/urls.py
@@ -14,8 +14,10 @@ router.register('clusters', ClusterViewSet)
 router.register('comments', CommentViewSet)
 router.register('requests', AllocationRequestViewSet)
 router.register('reviews', AllocationReviewViewSet)
+router.register('upload', FileUploadViewSet, basename="requests")
 
 urlpatterns = router.urls + [
     path('allocation-request/status-choices/', AllocationRequestStatusChoicesView.as_view()),
     path('allocation-review/status-choices/', AllocationReviewStatusChoicesView.as_view()),
+    #path('fileupload/upload/', FileUploadView.as_view())  
 ]

--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -149,20 +149,6 @@ class AttachmentViewSet(viewsets.ModelViewSet):
         return Attachment.objects.filter(request__team__in=teams)
 
 
-class FileUploadViewSet(ViewSet): 
-    serializer_class = FileUploadSerializer
-
-    def create(self, request):
-        file_uploaded = request.FILES.get('file_uploaded')
-        content_type = file_uploaded.content_type
-        path = ''
-        if file_uploaded:
-            filename = file_uploaded.name
-            path = default_storage.save(os.path.join('allocations', file_uploaded.name), file_uploaded)
-            
-        return Response(path)
-
-
 class ClusterViewSet(viewsets.ModelViewSet):
     """Configuration settings for managed Slurm clusters."""
 
@@ -188,3 +174,17 @@ class CommentViewSet(viewsets.ModelViewSet):
 
         teams = Team.objects.teams_for_user(self.request.user)
         return self.queryset.filter(request__team__in=teams)
+
+
+class FileUploadViewSet(ViewSet): 
+    serializer_class = FileUploadSerializer
+
+    def create(self, request):
+        file_uploaded = request.FILES.get('file_uploaded')
+        content_type = file_uploaded.content_type
+        path = ''
+        if file_uploaded:
+            filename = file_uploaded.name
+            path = default_storage.save(os.path.join('allocations', file_uploaded.name), file_uploaded)
+            
+        return Response(path)

--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -182,6 +182,7 @@ class FileUploadViewSet(ViewSet):
     def create(self, request):
         file_uploaded = request.FILES.get('file_uploaded')
         content_type = file_uploaded.content_type
+        # do something with validating content type
         path = ''
         if file_uploaded:
             filename = file_uploaded.name


### PR DESCRIPTION
Simple file upload that saves file to disk and returns the name of the saved file.  Uses the built in name collision to rename any file that has the same name