### PR TITLE
Adds middleware for generating default CID values

### DIFF
--- a/keystone_api/apps/logging/middleware.py
+++ b/keystone_api/apps/logging/middleware.py
@@ -5,12 +5,38 @@ cycle of incoming requests before they reach the application views or become
 an outgoing client response.
 """
 
+import uuid
+
 from django.conf import settings
 from django.http import HttpRequest
 
 from .models import RequestLog
 
 __all__ = ['LogRequestMiddleware']
+
+
+class DefaultCidMiddleware:
+    """Assign a default CID value when not provided by the client in the request header.
+
+    See the `AUDITLOG_CID_HEADER` setting for the header name used to store CID values.
+    """
+
+    # __init__ signature required by Django for dependency injection
+    def __init__(self, get_response: callable) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpRequest:
+        """Execute the middleware on an incoming HTTP request.
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            The processed request object.
+        """
+
+        request.META.setdefault(settings.AUDITLOG_CID_HEADER, uuid.uuid4().hex)
+        return self.get_response(request)
 
 
 class LogRequestMiddleware:

--- a/keystone_api/apps/logging/tests/test_middleware/test_DefaultCidMiddleware.py
+++ b/keystone_api/apps/logging/tests/test_middleware/test_DefaultCidMiddleware.py
@@ -1,0 +1,47 @@
+"""Unit tests for the `DefaultCidMiddleware` class."""
+
+import uuid
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import override_settings, TestCase
+from django.test.client import RequestFactory
+
+from apps.logging.middleware import DefaultCidMiddleware
+
+
+class DefaultCidAssignment(TestCase):
+    """Test the generation of Default CID values."""
+
+    def setUp(self) -> None:
+        """Instantiate common testing fixtures."""
+
+        self.rf = RequestFactory()
+        self.middleware = DefaultCidMiddleware(lambda request: HttpResponse())
+
+    @override_settings(AUDITLOG_CID_HEADER='X_CUSTOM_CID')
+    def test_sets_default_cid_if_missing(self) -> None:
+        """Verify a default CID is generated when the header is missing."""
+
+        # Create a request without a CID
+        request = self.rf.get('/some-path/')
+        self.assertNotIn(settings.AUDITLOG_CID_HEADER, request.META)
+
+        # Execute the response middleware
+        response = self.middleware(request)
+        cid = request.META.get('X_CUSTOM_CID')
+
+        self.assertIsNotNone(cid)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(uuid.UUID(cid))  # Validates UUID hex format
+
+    @override_settings(AUDITLOG_CID_HEADER='X_CUSTOM_CID')
+    def test_preserves_existing_cid(self) -> None:
+        """Verify an existing CID is not overwritten."""
+
+        existing_cid = uuid.uuid4().hex
+        request = self.rf.get('/some-path/')
+        request.META['X_CUSTOM_CID'] = existing_cid
+
+        self.middleware(request)
+        self.assertEqual(existing_cid, request.META['X_CUSTOM_CID'])

--- a/keystone_api/apps/logging/tests/test_middleware/test_LogRequestMiddleware.py
+++ b/keystone_api/apps/logging/tests/test_middleware/test_LogRequestMiddleware.py
@@ -24,7 +24,7 @@ class LoggingToDatabase(TestCase):
         middleware = LogRequestMiddleware(lambda x: HttpResponse())
         middleware(request)
 
-        self.assertEqual(RequestLog.objects.count(), 1)
+        self.assertEqual(1, RequestLog.objects.count())
         self.assertEqual(RequestLog.objects.first().user, request.user)
 
     def test_anonymous_user(self) -> None:
@@ -37,7 +37,7 @@ class LoggingToDatabase(TestCase):
         middleware = LogRequestMiddleware(lambda x: HttpResponse())
         middleware(request)
 
-        self.assertEqual(RequestLog.objects.count(), 1)
+        self.assertEqual(1, RequestLog.objects.count())
         self.assertIsNone(RequestLog.objects.first().user)
 
 
@@ -60,7 +60,7 @@ class ClientIPLogging(TestCase):
 
         self.middleware(request)
         log = RequestLog.objects.first()
-        self.assertEqual(log.remote_address, '192.168.1.1')
+        self.assertEqual('192.168.1.1', log.remote_address)
 
     def test_logs_ip_from_remote_addr(self) -> None:
         """Verify the client IP is logged from `REMOTE_ADDR` when `X-Forwarded-For` is missing."""
@@ -71,7 +71,7 @@ class ClientIPLogging(TestCase):
 
         self.middleware(request)
         log = RequestLog.objects.first()
-        self.assertEqual(log.remote_address, '192.168.1.1')
+        self.assertEqual('192.168.1.1', log.remote_address)
 
     def test_logs_none_if_no_ip_headers(self) -> None:
         """Verify `None` is logged when no IP headers are present."""
@@ -106,7 +106,7 @@ class CidLogging(TestCase):
 
         self.middleware(request)
         log = RequestLog.objects.first()
-        self.assertEqual(log.cid, cid_value)
+        self.assertEqual(cid_value, log.cid)
 
     def test_missing_cid_header(self) -> None:
         """Verify CID is logged as `None` when the CID header is not present."""

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'apps.logging.middleware.LogRequestMiddleware',
+    'apps.logging.middleware.DefaultCidMiddleware',
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
Ensures every incoming request is assigned a CID if not provided by the client.