### PR TITLE
Reorders cors middleware

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -106,11 +106,11 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'apps.logging.middleware.LogRequestMiddleware',
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'apps.logging.middleware.LogRequestMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
Fixes a bug reported by @Comeani where CORS headers aren't set properly by the API. The bug was introduced by a reordering of the application middleware in the most recent release, causing CORS headers to be stripped from responses.