### PR TITLE
Validate file types on file upload

### DIFF
--- a/keystone_api/apps/allocations/serializers.py
+++ b/keystone_api/apps/allocations/serializers.py
@@ -115,7 +115,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
         """Validate the uploaded file against size and type constraints.
 
         Returns:
-            UploadedFile: The validated file.
+            The validated file.
 
         Raises:
             serializers.ValidationError: If the file exceeds the size limit or has a disallowed MIME type.

--- a/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
+++ b/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
@@ -20,7 +20,7 @@ class ValidateFileMethod(TestCase):
         max_size = settings.MAX_FILE_SIZE
         file = SimpleUploadedFile("file.txt", b"x" * (max_size - 1))  # 1 KB
 
-        result = AttachmentSerializer.validate_file()
+        result = AttachmentSerializer.validate_file(file)
         self.assertEqual(result, file)
 
     def test_equals_size_limit(self) -> None:
@@ -29,7 +29,7 @@ class ValidateFileMethod(TestCase):
         max_size = settings.MAX_FILE_SIZE
         file = SimpleUploadedFile("large.txt", b"x" * max_size)
 
-        result = AttachmentSerializer.validate_file()
+        result = AttachmentSerializer.validate_file(file)
         self.assertEqual(result, file)
 
     def test_exceeds_size_limit(self) -> None:
@@ -39,6 +39,6 @@ class ValidateFileMethod(TestCase):
         file = SimpleUploadedFile("large.txt", b"x" * (max_size + 1))
 
         with self.assertRaises(ValidationError) as ctx:
-            AttachmentSerializer.validate_file()
+            AttachmentSerializer.validate_file(file)
 
         self.assertIn("File size should not exceed", str(ctx.exception))

--- a/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
+++ b/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
@@ -20,7 +20,7 @@ class ValidateFileMethod(TestCase):
         max_size = settings.MAX_FILE_SIZE
         file = SimpleUploadedFile("file.txt", b"x" * (max_size - 1))  # 1 KB
 
-        result = AttachmentSerializer.validate_file(file)
+        result = AttachmentSerializer.validate_file()
         self.assertEqual(result, file)
 
     def test_equals_size_limit(self) -> None:
@@ -29,7 +29,7 @@ class ValidateFileMethod(TestCase):
         max_size = settings.MAX_FILE_SIZE
         file = SimpleUploadedFile("large.txt", b"x" * max_size)
 
-        result = AttachmentSerializer.validate_file(file)
+        result = AttachmentSerializer.validate_file()
         self.assertEqual(result, file)
 
     def test_exceeds_size_limit(self) -> None:
@@ -39,6 +39,6 @@ class ValidateFileMethod(TestCase):
         file = SimpleUploadedFile("large.txt", b"x" * (max_size + 1))
 
         with self.assertRaises(ValidationError) as ctx:
-            AttachmentSerializer.validate_file(file)
+            AttachmentSerializer.validate_file()
 
         self.assertIn("File size should not exceed", str(ctx.exception))

--- a/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
+++ b/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
@@ -51,6 +51,6 @@ class ValidateFileMethod(TestCase):
     def test_disallowed_mime_type(self) -> None:
         """Verify a file with a disallowed MIME type fails validation."""
 
-        file = SimpleUploadedFile("image.gif", b"GIF87a...")
+        file = SimpleUploadedFile("text.exe", b"GIF87a...")
         with self.assertRaisesRegex(ValidationError, "File type .* is not allowed"):
             AttachmentSerializer.validate_file(file)

--- a/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
+++ b/keystone_api/apps/allocations/tests/test_serializers/test_AttachmentSerializer.py
@@ -38,7 +38,19 @@ class ValidateFileMethod(TestCase):
         max_size = settings.MAX_FILE_SIZE
         file = SimpleUploadedFile("large.txt", b"x" * (max_size + 1))
 
-        with self.assertRaises(ValidationError) as ctx:
+        with self.assertRaisesRegex(ValidationError, "File size should not exceed"):
             AttachmentSerializer.validate_file(file)
 
-        self.assertIn("File size should not exceed", str(ctx.exception))
+    def test_allowed_mime_type(self) -> None:
+        """Verify a file with an allowed MIME type passes validation."""
+
+        file = SimpleUploadedFile("test.txt", b"sample content")
+        result = AttachmentSerializer.validate_file(file)
+        self.assertEqual(result, file)
+
+    def test_disallowed_mime_type(self) -> None:
+        """Verify a file with a disallowed MIME type fails validation."""
+
+        file = SimpleUploadedFile("image.gif", b"GIF87a...")
+        with self.assertRaisesRegex(ValidationError, "File type .* is not allowed"):
+            AttachmentSerializer.validate_file(file)

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -61,10 +61,37 @@ CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=_trusted_local)
 
 ALLOWED_FILE_TYPES = [
-    'application/pdf',
-    'image/jpeg',
-    'image/png',
-    'text/plain',
+    # Documents
+    "application/pdf",
+    "application/rtf",
+    "application/msword",  # .doc
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+    "application/vnd.oasis.opendocument.text",  # .odt
+    "application/x-latex",  # .latex
+    "application/x-tex",  # .tex
+
+    # Spreadsheets
+    "application/vnd.ms-excel",  # .xls
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # .xlsx
+    "application/vnd.oasis.opendocument.spreadsheet",  # .ods
+
+    # Presentations
+    "application/vnd.ms-powerpoint",  # .ppt
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # .pptx
+
+    # Plain and structured text
+    "text/plain",  # .txt
+    "text/markdown",  # .md
+    "text/richtext",  # .rtx
+    "text/csv",  # .csv
+
+    # Images
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/svg+xml",
+    "image/tiff",
+    "image/bmp"
 ]
 
 # App Configuration

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -63,7 +63,8 @@ CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=_trusted_local
 ALLOWED_FILE_TYPES = [
     'application/pdf',
     'image/jpeg',
-    'image/png'
+    'image/png',
+    'text/plain',
 ]
 
 # App Configuration

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -60,6 +60,12 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_SUBDOMAINS", False)
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=_trusted_local)
 
+ALLOWED_FILE_TYPES = [
+    'application/pdf',
+    'image/jpeg',
+    'image/png'
+]
+
 # App Configuration
 
 ROOT_URLCONF = 'main.urls'


### PR DESCRIPTION
Explicitly lists the allowed file MIME types in settings and checks uploaded files against the whitelist. 

Mime types are determined using the `guess_type` method from the Python standard library. This method benefits from being builtin, but is limited to identifying file types exclusively from the file extension. There are more comprehensive alternatives that scan the file contents in memory, but many of the alternatives I found are not well maintained. A more robust approach can always be implemented in the future after some additional research.