### PR TITLE
Adds _user and _request fields to serialized comments

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -6549,6 +6549,16 @@ components:
         id:
           type: integer
           readOnly: true
+        _user:
+          allOf:
+          - $ref: '#/components/schemas/UserSummary'
+          readOnly: true
+          title: ' user'
+        _request:
+          allOf:
+          - $ref: '#/components/schemas/AllocationRequestSummary'
+          readOnly: true
+          title: ' request'
         user:
           type: integer
         content:
@@ -6563,6 +6573,8 @@ components:
         request:
           type: integer
       required:
+      - _request
+      - _user
       - content
       - created
       - id
@@ -6848,6 +6860,16 @@ components:
         id:
           type: integer
           readOnly: true
+        _user:
+          allOf:
+          - $ref: '#/components/schemas/UserSummary'
+          readOnly: true
+          title: ' user'
+        _request:
+          allOf:
+          - $ref: '#/components/schemas/AllocationRequestSummary'
+          readOnly: true
+          title: ' request'
         user:
           type: integer
         content:

--- a/keystone_api/apps/allocations/serializers.py
+++ b/keystone_api/apps/allocations/serializers.py
@@ -147,6 +147,8 @@ class ClusterSerializer(serializers.ModelSerializer):
 class CommentSerializer(serializers.ModelSerializer):
     """Object serializer for the `Comment` class."""
 
+    _user = UserSummarySerializer(source='user', read_only=True)
+    _request = AllocationRequestSummarySerializer(source='request', read_only=True)
     user = serializers.PrimaryKeyRelatedField(
         queryset=User.objects.all(),
         default=serializers.CurrentUserDefault()


### PR DESCRIPTION
Serialized comments records were missing a few nested fields. This PR adds them so the front-end doesn't need to submit multiple requests to the API.