### PR TITLE
Drops staff permission tests for openapi endpoints

### DIFF
--- a/keystone_api/tests/openapi/test_json.py
+++ b/keystone_api/tests/openapi/test_json.py
@@ -16,7 +16,6 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     |----------------------------|-----|------|---------|------|-----|-------|--------|-------|
     | Unauthenticated User       | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
     | Authenticated User         | 200 | 200  | 200     | 405  | 405 | 405   | 405    | 405   |
-    | Staff User                 | 200 | 200  | 200     | 405  | 405 | 405   | 405    | 405   |
     """
 
     endpoint = '/openapi/json'
@@ -25,7 +24,6 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Load user accounts from testing fixtures."""
 
-        self.staff_user = User.objects.get(username='staff_user')
         self.generic_user = User.objects.get(username='generic_user')
 
     def test_unauthenticated_user_permissions(self) -> None:
@@ -47,22 +45,6 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         """Verify authenticated have read-only permissions."""
 
         self.client.force_authenticate(user=self.generic_user)
-        self.assert_http_responses(
-            self.endpoint,
-            get=status.HTTP_200_OK,
-            head=status.HTTP_200_OK,
-            options=status.HTTP_200_OK,
-            post=status.HTTP_405_METHOD_NOT_ALLOWED,
-            put=status.HTTP_405_METHOD_NOT_ALLOWED,
-            patch=status.HTTP_405_METHOD_NOT_ALLOWED,
-            delete=status.HTTP_405_METHOD_NOT_ALLOWED,
-            trace=status.HTTP_405_METHOD_NOT_ALLOWED
-        )
-
-    def test_staff_user_permissions(self) -> None:
-        """Test staff users have read-only permissions."""
-
-        self.client.force_authenticate(user=self.staff_user)
         self.assert_http_responses(
             self.endpoint,
             get=status.HTTP_200_OK,

--- a/keystone_api/tests/openapi/test_yaml.py
+++ b/keystone_api/tests/openapi/test_yaml.py
@@ -16,7 +16,6 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     |----------------------------|-----|------|---------|------|-----|-------|--------|-------|
     | Unauthenticated User       | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
     | Authenticated User         | 200 | 200  | 200     | 405  | 405 | 405   | 405    | 405   |
-    | Staff User                 | 200 | 200  | 200     | 405  | 405 | 405   | 405    | 405   |
     """
 
     endpoint = '/openapi/yaml'
@@ -47,22 +46,6 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         """Verify authenticated users have read-only permissions."""
 
         self.client.force_authenticate(user=self.generic_user)
-        self.assert_http_responses(
-            self.endpoint,
-            get=status.HTTP_200_OK,
-            head=status.HTTP_200_OK,
-            options=status.HTTP_200_OK,
-            post=status.HTTP_405_METHOD_NOT_ALLOWED,
-            put=status.HTTP_405_METHOD_NOT_ALLOWED,
-            patch=status.HTTP_405_METHOD_NOT_ALLOWED,
-            delete=status.HTTP_405_METHOD_NOT_ALLOWED,
-            trace=status.HTTP_405_METHOD_NOT_ALLOWED
-        )
-
-    def test_staff_user_permissions(self) -> None:
-        """Verify staff users have read-only permissions."""
-
-        self.client.force_authenticate(user=self.staff_user)
         self.assert_http_responses(
             self.endpoint,
             get=status.HTTP_200_OK,


### PR DESCRIPTION
These tests are duplicates of the tests for generic authenticated users and are redundant.