### PR TITLE
Sandbox passwords and history from templates

### DIFF
--- a/keystone_api/plugins/email.py
+++ b/keystone_api/plugins/email.py
@@ -84,7 +84,7 @@ class EmlFileEmailBackend(BaseEmailBackend):
 class SecureSandboxedEnvironment(SandboxedEnvironment):
     """A security hardened Jinja2 environment that blocks access to insecure Django functionality."""
 
-    _forbidden_attrs = {'objects', }
+    _forbidden_attrs = {'objects', 'password', 'history'}
     _allowed_constructors = {str, int, float, bool, list, tuple, dict, set, frozenset}
 
     def is_safe_attribute(self, obj: object, attr: str, value: any) -> bool:

--- a/keystone_api/plugins/tests/test_email/test_SecureSandboxedEnvironment.py
+++ b/keystone_api/plugins/tests/test_email/test_SecureSandboxedEnvironment.py
@@ -24,8 +24,9 @@ class IsSafeAttributeMethod(SimpleTestCase):
     def test_blocks_forbidden_attributes(self) -> None:
         """Verify explicitly forbidden attributes are blocked."""
 
-        result = self.env.is_safe_attribute(object(), 'objects', None)
-        self.assertFalse(result)
+        self.assertFalse(self.env.is_safe_attribute(object(), 'objects', None))
+        self.assertFalse(self.env.is_safe_attribute(object(), 'password', None))
+        self.assertFalse(self.env.is_safe_attribute(object(), 'history', None))
 
     def test_allows_public_safe_attributes(self) -> None:
         """Verify normal public attributes are allowed."""


### PR DESCRIPTION
Ensures the password and history attributes are not accessible in email templates.