### PR TITLE
Adds default args to render_templates command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ keystone_api/keystone.db
 keystone_api/static_files/
 keystone_api/media/
 keystone_api/email/
+*.log
+*.eml
 
 # Distribution and packaging
 __pycache__/


### PR DESCRIPTION
Having now used the CLI `render_templates` command for a little while, I realize it would be a better user experience to provide sensible defaults to the input/output arguments.