### PR TITLE
Patches bug where filters are not applied

### DIFF
--- a/keystone_api/apps/users/mixins.py
+++ b/keystone_api/apps/users/mixins.py
@@ -18,7 +18,7 @@ from .models import Team
 __all__ = ['TeamScopedListMixin']
 
 
-class TeamScopedListMixin(ListModelMixin):
+class TeamScopedListMixin:
     """Adds team-based filtering to list views based on user access.
 
     Extends Model Viewset classes by filtering list response data

--- a/keystone_api/apps/users/mixins.py
+++ b/keystone_api/apps/users/mixins.py
@@ -8,6 +8,7 @@ combined with other mixins or base view classes as needed.
 from typing import Callable
 
 from django.db.models import QuerySet
+from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
@@ -17,7 +18,7 @@ from .models import Team
 __all__ = ['TeamScopedListMixin']
 
 
-class TeamScopedListMixin:
+class TeamScopedListMixin(ListModelMixin):
     """Adds team-based filtering to list views based on user access.
 
     Extends Model Viewset classes by filtering list response data
@@ -35,14 +36,18 @@ class TeamScopedListMixin:
     def list(self, request: Request) -> Response:
         """Return a list of serialized records filtered by user team permissions."""
 
-        if request.user.is_staff:
-            query = self.queryset
-
-        else:
+        queryset = self.filter_queryset(self.get_queryset())
+        if not request.user.is_staff:
             teams = Team.objects.teams_for_user(request.user)
-            query = self.queryset.filter(**{self.team_field + '__in': teams})
+            queryset = queryset.filter(**{self.team_field + '__in': teams})
 
-        return Response(self.get_serializer(query, many=True).data)
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 class UserScopedListMixin:
@@ -60,10 +65,14 @@ class UserScopedListMixin:
     def list(self, request: Request, *args, **kwargs) -> Response:
         """Return a list of serialized records filtered for the requesting user."""
 
-        if request.user.is_staff:
-            query = self.queryset
+        queryset = self.filter_queryset(self.get_queryset())
+        if not request.user.is_staff:
+            queryset = self.queryset.filter(**{self.user_field: request.user})
 
-        else:
-            query = self.queryset.filter(**{self.user_field: request.user})
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
 
-        return Response(self.get_serializer(query, many=True).data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/keystone_api/apps/users/mixins.py
+++ b/keystone_api/apps/users/mixins.py
@@ -8,7 +8,6 @@ combined with other mixins or base view classes as needed.
 from typing import Callable
 
 from django.db.models import QuerySet
-from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer


### PR DESCRIPTION
Fixes a bug with API query parameters are not used to filter/paginate response data for some endpoints.

The filtering of request data was abstracted into base classes for easier maintainability, but some logic was missed during the rewrite. This PR adds the missing logic back.