### PR TITLE
Update upcoming_expiration.html

### DIFF
--- a/keystone_api/templates/upcoming_expiration.html
+++ b/keystone_api/templates/upcoming_expiration.html
@@ -10,6 +10,9 @@
     This notification is to remind you your HPC compute allocation <strong>"{{ request.title }}"</strong>
     is set to expire in {{ days_to_expire }} days on {{ request.expire.isoformat() }}.
   </p>
+  <p>
+     You can renew your allocation following our guidelines given here: https://crc.pitt.edu/service-request-forms/compute-allocation-guidelines
+  </p>
   <p>Sincerely,</p>
   <p>The keystone HPC utility</p>
 {% endblock %}


### PR DESCRIPTION
Direct users to CRC's allocation guidelines page in email notifications so they know what to do to renew their allocation.