### PR TITLE
Adds endpoint for notification types

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -7959,6 +7959,9 @@ components:
       type: object
       description: Serializer for summarizing allocation requests in nested responses.
       properties:
+        id:
+          type: integer
+          readOnly: true
         title:
           type: string
           maxLength: 250
@@ -7973,6 +7976,7 @@ components:
           format: date
           nullable: true
       required:
+      - id
       - title
     AllocationReview:
       type: object
@@ -8252,12 +8256,16 @@ components:
       type: object
       description: Serializer for summarizing cluster names in nested responses.
       properties:
+        id:
+          type: integer
+          readOnly: true
         name:
           type: string
           maxLength: 50
         enabled:
           type: boolean
       required:
+      - id
       - name
     Comment:
       type: object
@@ -9546,12 +9554,16 @@ components:
       type: object
       description: Serializer for summarizing team records in nested responses.
       properties:
+        id:
+          type: integer
+          readOnly: true
         name:
           type: string
           maxLength: 255
         is_active:
           type: boolean
       required:
+      - id
       - name
     UserRole:
       type: object
@@ -9579,6 +9591,9 @@ components:
       type: object
       description: Serializer for summarizing user records in nested responses.
       properties:
+        id:
+          type: integer
+          readOnly: true
         username:
           type: string
           pattern: ^[\w.@+-]+$
@@ -9597,6 +9612,7 @@ components:
           nullable: true
           maxLength: 254
       required:
+      - id
       - username
     health_json_ok:
       type: object

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -5023,6 +5023,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/TaskResult'
           description: ''
+  /notifications/allocation-request/status-choices/:
+    get:
+      operationId: notifications_allocation_request_status_choices_retrieve
+      description: Retrieve valid notification types with human-readable labels.
+      summary: Retrieve valid notification types
+      tags:
+      - Notifications
+      security:
+      - tokenAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationTypeChoices'
+          description: ''
   /notifications/notifications/:
     get:
       operationId: notifications_notifications_list
@@ -8527,11 +8544,6 @@ components:
         id:
           type: integer
           readOnly: true
-        _user:
-          allOf:
-          - $ref: '#/components/schemas/UserSummary'
-          readOnly: true
-          title: ' user'
         time:
           type: string
           format: date-time
@@ -8544,9 +8556,6 @@ components:
         message:
           type: string
           readOnly: true
-        metadata:
-          readOnly: true
-          nullable: true
         notification_type:
           allOf:
           - $ref: '#/components/schemas/NotificationTypeEnum'
@@ -8554,15 +8563,31 @@ components:
         user:
           type: integer
           readOnly: true
+        _user:
+          allOf:
+          - $ref: '#/components/schemas/UserSummary'
+          readOnly: true
+          title: ' user'
       required:
       - _user
       - id
       - message
-      - metadata
       - notification_type
       - subject
       - time
       - user
+    NotificationTypeChoices:
+      type: object
+      properties:
+        GM:
+          type: string
+          default: General Message
+        RE:
+          type: string
+          default: Upcoming Request Expiration
+        RD:
+          type: string
+          default: Request Past Expiration
     NotificationTypeEnum:
       enum:
       - GM
@@ -8901,11 +8926,6 @@ components:
         id:
           type: integer
           readOnly: true
-        _user:
-          allOf:
-          - $ref: '#/components/schemas/UserSummary'
-          readOnly: true
-          title: ' user'
         time:
           type: string
           format: date-time
@@ -8918,9 +8938,6 @@ components:
         message:
           type: string
           readOnly: true
-        metadata:
-          readOnly: true
-          nullable: true
         notification_type:
           allOf:
           - $ref: '#/components/schemas/NotificationTypeEnum'
@@ -8928,6 +8945,11 @@ components:
         user:
           type: integer
           readOnly: true
+        _user:
+          allOf:
+          - $ref: '#/components/schemas/UserSummary'
+          readOnly: true
+          title: ' user'
     PatchedPreference:
       type: object
       description: Object serializer for the `Preference` class.

--- a/keystone_api/apps/allocations/factories.py
+++ b/keystone_api/apps/allocations/factories.py
@@ -134,7 +134,7 @@ class CommentFactory(DjangoModelFactory):
         model = Comment
 
     content = factory.Faker('sentence', nb_words=10)
-    private = factory.Faker('pybool', truth_probability=0.1)
+    private = factory.Faker('pybool', truth_probability=10)
 
     user = factory.SubFactory(UserFactory)
     request = factory.SubFactory(AllocationRequestFactory)

--- a/keystone_api/apps/allocations/nested.py
+++ b/keystone_api/apps/allocations/nested.py
@@ -24,7 +24,7 @@ class ClusterSummarySerializer(serializers.ModelSerializer):
         """Serializer settings."""
 
         model = Cluster
-        fields = ['name', 'enabled']
+        fields = ['id', 'name', 'enabled']
 
 
 class AllocationRequestSummarySerializer(serializers.ModelSerializer):
@@ -34,7 +34,7 @@ class AllocationRequestSummarySerializer(serializers.ModelSerializer):
         """Serializer settings."""
 
         model = AllocationRequest
-        fields = ['title', 'status', 'active', 'expire']
+        fields = ['id', 'title', 'status', 'active', 'expire']
 
 
 class AllocationSummarySerializer(serializers.ModelSerializer):

--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 
-@extend_schema_view(  # pragma: nocover
+@extend_schema_view(
     get=extend_schema(
         summary="Retrieve valid request status options",
         description="Retrieve valid allocation request `status` options with human-readable labels.",
@@ -50,7 +50,7 @@ class AllocationRequestStatusChoicesView(GetChoicesMixin, GenericAPIView):
     permission_classes = [IsAuthenticated]
 
 
-@extend_schema_view(  # pragma: nocover
+@extend_schema_view(
     get=extend_schema(
         summary="Retrieve valid review status options",
         description="Retrieve valid allocation review `status` options with human-readable labels.",

--- a/keystone_api/apps/notifications/factories.py
+++ b/keystone_api/apps/notifications/factories.py
@@ -27,7 +27,7 @@ class NotificationFactory(DjangoModelFactory):
     read = factory.Faker("pybool", truth_probability=0.3)
     subject = factory.Faker('sentence', nb_words=6)
     message = factory.Faker('paragraph', nb_sentences=3)
-    notification_type = randgen.choices(Notification.NotificationType.values)
+    notification_type = randgen.choice(Notification.NotificationType.values)
 
     user = factory.SubFactory(UserFactory)
 

--- a/keystone_api/apps/notifications/factories.py
+++ b/keystone_api/apps/notifications/factories.py
@@ -24,7 +24,7 @@ class NotificationFactory(DjangoModelFactory):
         model = Notification
 
     time = factory.Faker('date_time_this_year')
-    read = factory.Faker("pybool", truth_probability=0.3)
+    read = factory.Faker("pybool", truth_probability=30)
     subject = factory.Faker('sentence', nb_words=6)
     message = factory.Faker('paragraph', nb_sentences=3)
     notification_type = randgen.choice(Notification.NotificationType.values)
@@ -39,6 +39,6 @@ class PreferenceFactory(DjangoModelFactory):
         model = Preference
 
     request_expiry_thresholds = factory.LazyFunction(lambda: [30, 14])
-    notify_on_expiration = factory.Faker("pybool", truth_probability=0.75)
+    notify_on_expiration = factory.Faker("pybool", truth_probability=75)
 
     user = factory.SubFactory(UserFactory)

--- a/keystone_api/apps/notifications/serializers.py
+++ b/keystone_api/apps/notifications/serializers.py
@@ -27,7 +27,7 @@ class NotificationSerializer(serializers.ModelSerializer):
         """Serializer settings."""
 
         model = Notification
-        fields = ['time', 'read', 'subject', 'message', 'notification_type']
+        fields = ['id', 'time', 'read', 'subject', 'message', 'notification_type', 'user', '_user']
         read_only_fields = [f for f in fields if f != 'read']
 
 

--- a/keystone_api/apps/notifications/serializers.py
+++ b/keystone_api/apps/notifications/serializers.py
@@ -27,8 +27,8 @@ class NotificationSerializer(serializers.ModelSerializer):
         """Serializer settings."""
 
         model = Notification
-        fields = '__all__'
-        read_only_fields = [f.name for f in Notification._meta.fields if f.name != 'read']
+        fields = ['time', 'read', 'subject', 'message', 'notification_type']
+        read_only_fields = [f for f in fields if f != 'read']
 
 
 class PreferenceSerializer(serializers.ModelSerializer):

--- a/keystone_api/apps/notifications/urls.py
+++ b/keystone_api/apps/notifications/urls.py
@@ -1,5 +1,6 @@
 """URL routing for the parent application."""
 
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .views import *
@@ -10,4 +11,6 @@ router = DefaultRouter()
 router.register('notifications', NotificationViewSet)
 router.register('preferences', PreferenceViewSet)
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path('allocation-request/status-choices/', NotificationTypeChoicesView.as_view()),
+]

--- a/keystone_api/apps/notifications/views.py
+++ b/keystone_api/apps/notifications/views.py
@@ -6,8 +6,9 @@ serve as the controller layer in Django's MVC-inspired architecture, bridging
 URLs to business logic.
 """
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import status, viewsets
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
+from rest_framework import serializers, status, viewsets
+from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,9 +19,33 @@ from .permissions import *
 from .serializers import *
 
 __all__ = [
+    'NotificationTypeChoicesView',
     'NotificationViewSet',
     'PreferenceViewSet',
 ]
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary="Retrieve valid notification types",
+        description="Retrieve valid notification types with human-readable labels.",
+        tags=["Notifications"],
+        responses=inline_serializer(
+            name="NotificationTypeChoices",
+            fields={k: serializers.CharField(default=v) for k, v in Notification.NotificationType.choices}
+        )
+    )
+)
+class NotificationTypeChoicesView(GenericAPIView):
+    """API endpoints for exposing valid notification `type` values."""
+
+    response_content = dict(Notification.NotificationType.choices)
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        """Return a dictionary mapping values to human-readable names."""
+
+        return Response(self.response_content)
 
 
 @extend_schema_view(

--- a/keystone_api/apps/research_products/factories.py
+++ b/keystone_api/apps/research_products/factories.py
@@ -51,7 +51,7 @@ class PublicationFactory(DjangoModelFactory):
     abstract = factory.Faker("paragraph", nb_sentences=5)
     journal = factory.Faker("catch_phrase")
     doi = factory.Faker('doi')
-    preparation = factory.Faker("pybool", truth_probability=0.2)
+    preparation = factory.Faker("pybool", truth_probability=20)
     volume = factory.Faker("numerify", text="##")
     issue = factory.Faker("numerify", text="#")
 

--- a/keystone_api/apps/users/factories.py
+++ b/keystone_api/apps/users/factories.py
@@ -33,7 +33,7 @@ class UserFactory(DjangoModelFactory):
     department = factory.Faker('bs')
     role = factory.Faker('job')
 
-    is_active = factory.Faker('pybool', truth_probability=0.98)
+    is_active = factory.Faker('pybool', truth_probability=98)
     is_staff = factory.Faker('pybool')
     is_ldap_user = False
 

--- a/keystone_api/apps/users/mixins.py
+++ b/keystone_api/apps/users/mixins.py
@@ -65,8 +65,9 @@ class UserScopedListMixin:
         """Return a list of serialized records filtered for the requesting user."""
 
         queryset = self.filter_queryset(self.get_queryset())
+
         if not request.user.is_staff:
-            queryset = self.queryset.filter(**{self.user_field: request.user})
+            queryset = queryset.filter(**{self.user_field: request.user})
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/keystone_api/apps/users/nested.py
+++ b/keystone_api/apps/users/nested.py
@@ -25,7 +25,7 @@ class UserSummarySerializer(serializers.ModelSerializer):
         """Serializer settings."""
 
         model = User
-        fields = ["username", "first_name", "last_name", "email"]
+        fields = ["id", "username", "first_name", "last_name", "email"]
 
 
 class UserRoleSerializer(serializers.ModelSerializer):
@@ -47,7 +47,7 @@ class TeamSummarySerializer(serializers.ModelSerializer):
         """Serializer settings."""
 
         model = Team
-        fields = ["name", "is_active"]
+        fields = ["id", "name", "is_active"]
 
 
 class TeamRoleSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Adds a dedicated endpoint for fetching valid notification types. Also includes minor fixes like:

- Adds missing `id` field to nested some representations
- Fixes bug in generation of mock user notifications