### PR TITLE
Uses pre-hashed values in user factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 # IDE / Developer
 .idea/
 *.env
+*.pstats
 
 # OS
 .DS_Store

--- a/keystone_api/apps/users/factories.py
+++ b/keystone_api/apps/users/factories.py
@@ -8,6 +8,7 @@ setup logic.
 """
 
 import factory
+from django.contrib.auth.hashers import make_password
 from factory.django import DjangoModelFactory
 from factory.random import randgen
 
@@ -45,8 +46,11 @@ class UserFactory(DjangoModelFactory):
         model = User
         django_get_or_create = ('username',)
 
+    # Using a fixed, prehashed default password avoids the significant overhead
+    # of hashing a dynamically generated value for each record
+    password = make_password('password')
+
     username = factory.Sequence(lambda n: f"user{n}")
-    password = factory.PostGenerationMethodCall('set_password', 'password123!')
     first_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')
     email = factory.LazyAttribute(lambda obj: f"{obj.username}@example.com")


### PR DESCRIPTION
The mock data generation process previously created a random password for each user, resulting in a unique hash calculation per user. This introduced significant overhead, particularly when generating large datasets.

Profiling results for generating 500 users (400 general, 100 staff) showed total runtime of ~150 seconds. By prehashing a single password value and reusing it across all users, the runtime is reduced to ~50 seconds—a 3x improvement.

[profile_results.zip](https://github.com/user-attachments/files/21261119/Archive.zip)
