### PR TITLE
Allows unbound instances of builtin methods in email templates

### DIFF
--- a/keystone_api/plugins/tests/test_email/test_SecureSandboxedEnvironment.py
+++ b/keystone_api/plugins/tests/test_email/test_SecureSandboxedEnvironment.py
@@ -97,3 +97,10 @@ class IsSafeCallableMethod(SimpleTestCase):
 
         self.assertFalse(self.env.is_safe_callable(DangerousStr))
         self.assertFalse(self.env.is_safe_callable(DangerousStr("hello").secret))
+
+    def test_allows_unbound_primitive_methods(self) -> None:
+        """Verify unbound methods from primitive types (e.g., str.format) are allowed."""
+
+        self.assertTrue(self.env.is_safe_callable(str.format))
+        self.assertTrue(self.env.is_safe_callable(list.append))
+        self.assertTrue(self.env.is_safe_callable(dict.get))


### PR DESCRIPTION
Updates the `SecureSandboxedEnvironment.is_safe_callable` method to allow Jinja2 macros and unbound methods from primitive types (e.g., str.format, list.append) while maintaining strict blocking of unsafe callables.

Builtin methods like `[].append` or `"abc".format` were meant to be allowed in templates. But because of how Jinja2 processes templates, these methods sometimes show up as “unbound” (not attached to a specific object). Before this change, the sandbox blocked these unbound methods by mistake. Now, the code correctly recognizes and allows them, so templates can use these common methods safely without causing errors.