### PR TITLE
Fixes missing _actor field in audit log summaries

### DIFF
--- a/keystone_api/apps/logging/nested.py
+++ b/keystone_api/apps/logging/nested.py
@@ -18,7 +18,7 @@ __all__ = ['AuditLogSummarySerializer']
 class AuditLogSummarySerializer(serializers.ModelSerializer):
     """Object serializer for the `AuditLog` class."""
 
-    _actor = UserSummarySerializer(source='user', read_only=True)
+    _actor = UserSummarySerializer(source='actor', read_only=True)
     action = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
Looks like there was a typo in the `AuditLogSummarySerializer` class which resulted in the _actor field being omitted in serialized responses. The field was trying to serialize a database field called `user` when the DB field is actually called `actor`.