### PR TITLE
Fixes bug where failing health checks are not cached

### DIFF
--- a/keystone_api/apps/health/tests/test_views/test_BaseHealthCheckView.py
+++ b/keystone_api/apps/health/tests/test_views/test_BaseHealthCheckView.py
@@ -37,7 +37,7 @@ class GetMethod(TestCase):
         mock_check.assert_called_once()
 
     def test_response_is_cached(self, mock_check: Mock) -> None:
-        """Verify response is cached after processing get requests."""
+        """Verify responses are cached after processing get requests."""
 
         request = HttpRequest()
         view = ConcreteHealthCheckView()
@@ -50,7 +50,7 @@ class GetMethod(TestCase):
         self.assertEqual(response.content, cached_response.content)
 
     def test_cached_response_skips_checks(self, mock_check: Mock) -> None:
-        """Verify the cached response is returned when available and `check` is NOT called"""
+        """Verify cached responses are returned instead of evaluating system checks."""
 
         request = HttpRequest()
         view = ConcreteHealthCheckView()

--- a/keystone_api/apps/health/tests/test_views/test_BaseHealthCheckView.py
+++ b/keystone_api/apps/health/tests/test_views/test_BaseHealthCheckView.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import Mock, patch
 
+from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from django.test import TestCase
 
@@ -16,10 +17,15 @@ class ConcreteHealthCheckView(BaseHealthCheckView):
         return HttpResponse("OK", status=200)
 
 
+@patch.object(BaseHealthCheckView, 'check')
 class GetMethod(TestCase):
     """Test the handling of `GET` requests via the `get` method."""
 
-    @patch.object(BaseHealthCheckView, 'check')
+    def setUp(self) -> None:
+        """Clear any cached request/response data before running tests."""
+
+        cache.delete(BaseHealthCheckView._cache_key)
+
     def test_status_checks_are_run(self, mock_check: Mock) -> None:
         """Verify status checks are updated when processing get requests"""
 
@@ -29,3 +35,32 @@ class GetMethod(TestCase):
 
         # Test the method for updating health checks was run
         mock_check.assert_called_once()
+
+    def test_response_is_cached_after_get(self, mock_check: Mock) -> None:
+        """Verify response is cached after processing get requests."""
+
+        request = HttpRequest()
+        view = ConcreteHealthCheckView()
+        response = view.get(request)
+
+        # Response should now be cached
+        cached_response = cache.get(BaseHealthCheckView._cache_key)
+        self.assertIsNotNone(cached_response)
+        self.assertEqual(response.status_code, cached_response.status_code)
+        self.assertEqual(response.content, cached_response.content)
+
+    def test_cached_response_is_returned_without_check(self, mock_check: Mock) -> None:
+        """Verify the cached response is returned when available and `check` is NOT called"""
+
+        request = HttpRequest()
+        view = ConcreteHealthCheckView()
+
+        # Create and cache a fake HttpResponse
+        fake_response = HttpResponse("cached content")
+        cache.set(BaseHealthCheckView._cache_key, fake_response, 60)
+
+        response = view.get(request)
+
+        mock_check.assert_not_called()
+        self.assertEqual(fake_response.status_code, response.status_code)
+        self.assertEqual(fake_response.content, response.content)


### PR DESCRIPTION
Certain health checks trigger backend actions that are not individually resource-intensive but can cumulatively lead to significant system load when invoked at high volumes. This poses a potential denial-of-service (DoS) risk triggered by high request volumes.

To mitigate this risk, health check responses are cached for 60 seconds, effectively limiting the execution of each health check to once per minute. This PR fixes a bug where results were only cached for 2xx responses, resulting in no cache being used if the system health checks were failing.