### PR TITLE
Fixes typo in setting name causing LDAP sync task to fail

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -299,7 +299,7 @@ else:
 AUTH_USER_MODEL = "users.User"
 AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
 
-PURGE_REMOVED_LDAP_USERS = env.bool("AUTH_LDAP_PURGE_REMOVED", False)
+AUTH_LDAP_PURGE_REMOVED = env.bool("AUTH_LDAP_PURGE_REMOVED", False)
 if AUTH_LDAP_SERVER_URI := env.url("AUTH_LDAP_SERVER_URI", "").geturl():
     import ldap
     from django_auth_ldap.config import LDAPSearch


### PR DESCRIPTION
The application code is looking for a setting called `AUTH_LDAP_PURGE_REMOVED` but it was mistakenly parsed to a variable called `PURGE_REMOVED_LDAP_USERS`. This is causing the LDAP synchronization task to fail.

```
Traceback (most recent call last):
File "/home/keystone/.local/share/pipx/venvs/keystone-api/lib64/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
R = retval = fun(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^
File "/home/keystone/.local/share/pipx/venvs/keystone-api/lib64/python3.11/site-packages/celery/app/trace.py", line 736, in __protected_call__
return self.run(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/keystone/.local/share/pipx/venvs/keystone-api/lib/python3.11/site-packages/keystone_api/apps/users/tasks.py", line 73, in ldap_update_users
if settings.AUTH_LDAP_PURGE_REMOVED:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/keystone/.local/share/pipx/venvs/keystone-api/lib64/python3.11/site-packages/django/conf/__init__.py", line 83, in __getattr__
val = getattr(_wrapped, name)
^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Settings' object has no attribute 'AUTH_LDAP_PURGE_REMOVED'
```