### PR TITLE
Set user permissions to constant values in UserFactory

### DIFF
--- a/keystone_api/apps/allocations/factories.py
+++ b/keystone_api/apps/allocations/factories.py
@@ -58,7 +58,7 @@ class AllocationRequestFactory(DjangoModelFactory):
     description = factory.Faker('text', max_nb_chars=2000)
     submitted = factory.Faker('date_time_between', start_date="-5y", end_date="now", tzinfo=timezone.get_default_timezone())
 
-    submitter = factory.SubFactory(UserFactory, is_staff=False)
+    submitter = factory.SubFactory(UserFactory)
     team = factory.SubFactory(TeamFactory)
 
     @factory.lazy_attribute
@@ -195,7 +195,7 @@ class AllocationReviewFactory(DjangoModelFactory):
     status = LazyFunction(lambda: randgen.choice(AllocationReview.StatusChoices.values))
 
     request = factory.SubFactory(AllocationRequestFactory)
-    reviewer = factory.SubFactory(UserFactory, is_staff=False)
+    reviewer = factory.SubFactory(UserFactory, is_staff=True)
 
     @factory.lazy_attribute
     def submitted(self) -> date:
@@ -239,7 +239,7 @@ class CommentFactory(DjangoModelFactory):
     content = factory.Faker('sentence', nb_words=10)
     private = factory.Faker('pybool', truth_probability=10)
 
-    user = factory.SubFactory(UserFactory, is_staff=False)
+    user = factory.SubFactory(UserFactory)
     request = factory.SubFactory(AllocationRequestFactory)
 
 

--- a/keystone_api/apps/notifications/factories.py
+++ b/keystone_api/apps/notifications/factories.py
@@ -32,7 +32,7 @@ class NotificationFactory(DjangoModelFactory):
     message = factory.Faker('paragraph', nb_sentences=3)
     notification_type = LazyFunction(lambda: randgen.choice(Notification.NotificationType.values))
 
-    user = factory.SubFactory(UserFactory, is_staff=False)
+    user = factory.SubFactory(UserFactory)
 
 
 class PreferenceFactory(DjangoModelFactory):
@@ -46,4 +46,4 @@ class PreferenceFactory(DjangoModelFactory):
     request_expiry_thresholds = factory.LazyFunction(default_expiry_thresholds)
     notify_on_expiration = True
 
-    user = factory.SubFactory(UserFactory, is_staff=False)
+    user = factory.SubFactory(UserFactory)

--- a/keystone_api/apps/users/factories.py
+++ b/keystone_api/apps/users/factories.py
@@ -62,9 +62,10 @@ class UserFactory(DjangoModelFactory):
     department = factory.Faker('bs')
     role = factory.Faker('job')
 
-    is_active = factory.Faker('pybool', truth_probability=98)
-    is_staff = factory.Faker('pybool')
+    is_active = True
+    is_staff = False
     is_ldap_user = False
+
     date_joined = factory.Faker('date_time_between', start_date='-5y', end_date='now', tzinfo=timezone.get_default_timezone())
 
     @factory.post_generation
@@ -91,5 +92,5 @@ class MembershipFactory(DjangoModelFactory):
 
     role = LazyFunction(lambda: randgen.choice(Membership.Role.values))
 
-    user = factory.SubFactory(UserFactory, is_staff=False)
+    user = factory.SubFactory(UserFactory)
     team = factory.SubFactory(TeamFactory)

--- a/keystone_api/apps/users/tests/test_views/test_UserViewSet.py
+++ b/keystone_api/apps/users/tests/test_views/test_UserViewSet.py
@@ -14,8 +14,8 @@ class GetSerializerClassMethod(TestCase):
     def setUp(self) -> None:
         """Create user accounts for testing"""
 
+        self.regular_user = User.objects.create(username='regularuser')
         self.staff_user = User.objects.create(username='staffuser', is_staff=True)
-        self.regular_user = User.objects.create(username='regularuser', is_staff=False)
 
     def test_get_serializer_class_for_staff_user(self) -> None:
         """Verify the `PrivilegeUserSerializer` serializer is returned for a staff user."""

--- a/keystone_api/tests/allocations/common.py
+++ b/keystone_api/tests/allocations/common.py
@@ -20,8 +20,7 @@ class GetResponseContentTests:
     def test_returns_expected_content(self: TAPITestCase) -> None:
         """Verify GET responses include the expected content."""
 
-        generic_user = UserFactory(is_staff=False)
-        self.client.force_authenticate(user=generic_user)
+        self.client.force_authenticate(user=UserFactory())
 
         response = self.client.get(self.endpoint)
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/keystone_api/tests/allocations/test_allocation_request__status_choices.py
+++ b/keystone_api/tests/allocations/test_allocation_request__status_choices.py
@@ -27,7 +27,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_allocation_review__status_choices.py
+++ b/keystone_api/tests/allocations/test_allocation_review__status_choices.py
@@ -27,7 +27,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_allocations.py
+++ b/keystone_api/tests/allocations/test_allocations.py
@@ -26,7 +26,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         """Create test fixtures using mock data."""
 
         AllocationFactory()
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_allocations_pk.py
+++ b/keystone_api/tests/allocations/test_allocations_pk.py
@@ -33,8 +33,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team = self.allocation.request.team
         self.team_member = MembershipFactory(team=self.team, role=Membership.Role.MEMBER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.endpoint = self.endpoint_pattern.format(pk=self.allocation.pk)
 

--- a/keystone_api/tests/allocations/test_attachments.py
+++ b/keystone_api/tests/allocations/test_attachments.py
@@ -27,7 +27,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         """Create test fixtures using mock data."""
 
         AttachmentFactory()
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_attachments_pk.py
+++ b/keystone_api/tests/allocations/test_attachments_pk.py
@@ -32,7 +32,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         attachment = AttachmentFactory()
 
         self.team = attachment.request.team
-        self.non_member = UserFactory(is_staff=False)
+        self.non_member = UserFactory()
         self.team_member = MembershipFactory(team=self.team, role=Membership.Role.MEMBER).user
 
         self.staff_user = UserFactory(is_staff=True)

--- a/keystone_api/tests/allocations/test_clusters.py
+++ b/keystone_api/tests/allocations/test_clusters.py
@@ -26,7 +26,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         """Create test fixtures using mock data."""
 
         ClusterFactory()
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_clusters_pk.py
+++ b/keystone_api/tests/allocations/test_clusters_pk.py
@@ -28,7 +28,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         cluster = ClusterFactory()
         self.endpoint = self.endpoint_pattern.format(pk=cluster.id)
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_comments.py
+++ b/keystone_api/tests/allocations/test_comments.py
@@ -37,8 +37,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.valid_record_data = {'content': 'foo', 'request': self.request.pk}
 

--- a/keystone_api/tests/allocations/test_comments_pk.py
+++ b/keystone_api/tests/allocations/test_comments_pk.py
@@ -38,8 +38,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.endpoint = self.endpoint_pattern.format(pk=self.comment.pk)
         self.record_data = {'content': 'foobar', 'request': self.request.pk}

--- a/keystone_api/tests/allocations/test_jobs.py
+++ b/keystone_api/tests/allocations/test_jobs.py
@@ -25,8 +25,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        JobStatsFactory()
-        self.generic_user = UserFactory(is_staff=False)
+        self.job_stat = JobStatsFactory()
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/allocations/test_jobs_pk.py
+++ b/keystone_api/tests/allocations/test_jobs_pk.py
@@ -32,8 +32,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team = self.jobstat.team
         self.team_member = MembershipFactory(team=self.team, role=Membership.Role.MEMBER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.endpoint = self.endpoint_pattern.format(pk=self.jobstat.pk)
 

--- a/keystone_api/tests/allocations/test_requests.py
+++ b/keystone_api/tests/allocations/test_requests.py
@@ -37,8 +37,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.valid_record_data = {'title': 'foo', 'description': 'bar', 'team': self.team.pk}
 

--- a/keystone_api/tests/allocations/test_requests_pk.py
+++ b/keystone_api/tests/allocations/test_requests_pk.py
@@ -37,8 +37,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.endpoint = self.endpoint_pattern.format(pk=self.request.pk)
 

--- a/keystone_api/tests/allocations/test_reviews.py
+++ b/keystone_api/tests/allocations/test_reviews.py
@@ -28,7 +28,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
         self.review = AllocationReviewFactory()
 
@@ -92,7 +92,7 @@ class ReviewerAssignment(APITestCase):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
         self.request = AllocationRequestFactory()
 

--- a/keystone_api/tests/allocations/test_reviews_pk.py
+++ b/keystone_api/tests/allocations/test_reviews_pk.py
@@ -32,8 +32,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team = self.review.request.team
         self.team_member = MembershipFactory(team=self.team, role=Membership.Role.MEMBER).user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         self.endpoint = self.endpoint_pattern.format(pk=self.review.pk)
 

--- a/keystone_api/tests/authentication/test_login.py
+++ b/keystone_api/tests/authentication/test_login.py
@@ -23,7 +23,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.user = UserFactory(username='user', is_staff=False)
+        self.user = UserFactory(username='user')
         self.user.set_password('foobar123')
         self.user.save()
 
@@ -71,7 +71,7 @@ class UserAuthentication(APITestCase):
         """Create test fixtures using mock data."""
 
         self.password = 'foobar123'
-        self.user = UserFactory(username='user', password=self.password, is_staff=False)
+        self.user = UserFactory(username='user', password=self.password)
 
     def test_invalid_credentials(self) -> None:
         """Verify user authentication fails with invalid credentials."""

--- a/keystone_api/tests/authentication/test_logout.py
+++ b/keystone_api/tests/authentication/test_logout.py
@@ -38,8 +38,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def test_authenticated_user_permissions(self) -> None:
         """Verify authenticated users can submit post requests."""
 
-        user = UserFactory(is_staff=False)
-        self.client.force_authenticate(user=user)
+        self.client.force_authenticate(user=UserFactory())
         self.assert_http_responses(
             self.endpoint,
             get=status.HTTP_405_METHOD_NOT_ALLOWED,
@@ -64,7 +63,7 @@ class UserAuthentication(APITestCase):
         """Create test fixtures using mock data."""
 
         self.password = 'foobar123'
-        self.user = UserFactory(username='user', password=self.password, is_staff=False)
+        self.user = UserFactory(username='user', password=self.password)
 
     def assert_authentication(self, auth_status: bool) -> None:
         """Assert whether the current client session is authenticated.

--- a/keystone_api/tests/authentication/test_whoami.py
+++ b/keystone_api/tests/authentication/test_whoami.py
@@ -40,8 +40,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def test_authenticated_user_permissions(self) -> None:
         """Verify authenticated users can perform read operations."""
 
-        user = UserFactory(is_staff=False)
-        self.client.force_authenticate(user=user)
+        self.client.force_authenticate(user=UserFactory())
         self.assert_http_responses(
             self.endpoint,
             get=status.HTTP_200_OK,
@@ -63,7 +62,7 @@ class UserData(APITestCase):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.user = UserFactory(is_staff=False)
+        self.user = UserFactory()
 
     def test_metadata_is_returned(self) -> None:
         """Verify GET responses include metadata for the currently authenticated user."""

--- a/keystone_api/tests/health/test.py
+++ b/keystone_api/tests/health/test.py
@@ -29,7 +29,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self, _mock_run_check: Mock) -> None:

--- a/keystone_api/tests/health/test_json.py
+++ b/keystone_api/tests/health/test_json.py
@@ -27,7 +27,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self, _mock_run_check: Mock) -> None:

--- a/keystone_api/tests/health/test_prom.py
+++ b/keystone_api/tests/health/test_prom.py
@@ -28,7 +28,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self, _mock_run_check: Mock) -> None:

--- a/keystone_api/tests/logs/common.py
+++ b/keystone_api/tests/logs/common.py
@@ -32,7 +32,7 @@ class LogEndpointPermissionTestMixin(CustomAsserts, ABC):
     def setUp(self: TApiTestCase) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_anonymous_user_permissions(self: TApiTestCase) -> None:

--- a/keystone_api/tests/metrics/test.py
+++ b/keystone_api/tests/metrics/test.py
@@ -23,7 +23,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
 
     def test_unauthenticated_user_permissions(self) -> None:
         """Verify unauthenticated users have read-only permissions."""

--- a/keystone_api/tests/notifications/test_notifications.py
+++ b/keystone_api/tests/notifications/test_notifications.py
@@ -27,7 +27,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/notifications/test_notifications_pk.py
+++ b/keystone_api/tests/notifications/test_notifications_pk.py
@@ -26,8 +26,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.notified_user = UserFactory(is_staff=False)
-        self.generic_user = UserFactory(is_staff=False)
+        self.notified_user = UserFactory()
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.notification = NotificationFactory(user=self.notified_user)

--- a/keystone_api/tests/notifications/test_preferences.py
+++ b/keystone_api/tests/notifications/test_preferences.py
@@ -27,7 +27,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:
@@ -86,8 +86,8 @@ class UserFieldAssignment(APITestCase):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.user1 = UserFactory(is_staff=False)
-        self.user2 = UserFactory(is_staff=False)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_default_user(self) -> None:

--- a/keystone_api/tests/notifications/test_preferences_pk.py
+++ b/keystone_api/tests/notifications/test_preferences_pk.py
@@ -26,8 +26,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.preference_user = UserFactory(is_staff=False)
-        self.generic_user = UserFactory(is_staff=False)
+        self.preference_user = UserFactory()
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.preference = PreferenceFactory(user=self.preference_user)

--- a/keystone_api/tests/openapi/test_json.py
+++ b/keystone_api/tests/openapi/test_json.py
@@ -23,7 +23,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
 
     def test_unauthenticated_user_permissions(self) -> None:
         """Verify unauthenticated users cannot access resources."""

--- a/keystone_api/tests/openapi/test_yaml.py
+++ b/keystone_api/tests/openapi/test_yaml.py
@@ -23,7 +23,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/research/common.py
+++ b/keystone_api/tests/research/common.py
@@ -52,7 +52,7 @@ class ResearchListEndpointPermissionsTestMixin(CustomAsserts, ABC):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.valid_record_data = self.build_valid_record_data()
@@ -207,8 +207,8 @@ class ResearchDetailEndpointPermissionsTestMixin(CustomAsserts, ABC):
         self.team = membership.team
         self.team_member = membership.user
 
+        self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
-        self.non_member = UserFactory(is_staff=False)
 
         record = self.factory(team=self.team)
         self.endpoint = self.endpoint_pattern.format(pk=record.pk)

--- a/keystone_api/tests/users/test_membership.py
+++ b/keystone_api/tests/users/test_membership.py
@@ -34,7 +34,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
-        self.non_team_member = UserFactory(is_staff=False)
+        self.non_team_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/users/test_membership_pk.py
+++ b/keystone_api/tests/users/test_membership_pk.py
@@ -38,7 +38,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=membership.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=membership.team, role=Membership.Role.OWNER).user
 
-        self.non_team_member = UserFactory(is_staff=False)
+        self.non_team_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.member1_endpoint = self.endpoint_pattern.format(pk=membership.pk)

--- a/keystone_api/tests/users/test_team_membership__role_choices.py
+++ b/keystone_api/tests/users/test_team_membership__role_choices.py
@@ -23,7 +23,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
 
     def test_unauthenticated_user_permissions(self) -> None:
         """Verify unauthenticated users cannot access resources."""

--- a/keystone_api/tests/users/test_teams.py
+++ b/keystone_api/tests/users/test_teams.py
@@ -24,7 +24,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:

--- a/keystone_api/tests/users/test_teams_pk.py
+++ b/keystone_api/tests/users/test_teams_pk.py
@@ -34,7 +34,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
-        self.non_team_member = UserFactory(is_staff=False)
+        self.non_team_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.team_endpoint = self.endpoint_pattern.format(pk=self.team.pk)

--- a/keystone_api/tests/users/test_users.py
+++ b/keystone_api/tests/users/test_users.py
@@ -25,7 +25,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_unauthenticated_user_permissions(self) -> None:
@@ -88,7 +88,7 @@ class CredentialHandling(APITestCase):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
     def test_new_user_credentials_are_set(self) -> None:

--- a/keystone_api/tests/users/test_users_pk.py
+++ b/keystone_api/tests/users/test_users_pk.py
@@ -27,8 +27,8 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.user1 = UserFactory(is_staff=False)
-        self.user2 = UserFactory(is_staff=False)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.user1_endpoint = self.endpoint_pattern.format(pk=self.user1.id)
@@ -119,8 +119,8 @@ class CredentialHandling(APITestCase):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.user1 = UserFactory(is_staff=False)
-        self.user2 = UserFactory(is_staff=False)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.user1_endpoint = self.endpoint_pattern.format(pk=self.user1.id)
@@ -189,7 +189,7 @@ class RecordHistory(APITestCase):
     def setUp(self) -> None:
         """Authenticate as a generic application user."""
 
-        user = UserFactory(is_staff=False)
+        user = UserFactory()
         self.client.force_authenticate(user=user)
         self.endpoint = self.endpoint_pattern.format(pk=user.id)
 

--- a/keystone_api/tests/utils.py
+++ b/keystone_api/tests/utils.py
@@ -101,7 +101,7 @@ class TeamScopedListFilteringTestMixin(ABC):
         self.team = TeamFactory()
         self.team_member = MembershipFactory(team=self.team, role=Membership.Role.MEMBER).user
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.team_records = [self.factory(**{self.team_field: self.team}) for _ in range(5)]
@@ -167,8 +167,8 @@ class UserScopedListFilteringTestMixin:
     def setUp(self: TApiTestCase) -> None:
         """Create test fixtures using mock data."""
 
-        self.owner_user = UserFactory(is_staff=False)
-        self.other_user = UserFactory(is_staff=False)
+        self.owner_user = UserFactory()
+        self.other_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
         self.user_records = [self.factory(**{self.user_field: self.owner_user}), ]

--- a/keystone_api/tests/version/test.py
+++ b/keystone_api/tests/version/test.py
@@ -23,7 +23,7 @@ class EndpointPermissions(APITransactionTestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.generic_user = UserFactory(is_staff=False)
+        self.generic_user = UserFactory()
 
     def test_unauthenticated_user_permissions(self) -> None:
         """Verify unauthenticated users have read-only permissions."""


### PR DESCRIPTION
This PR updates the user factory to set `is_active=True` and `is_staff=False` by default. Previously, these fields were randomly assigned, which could cause unexpected test failures when they were not explicitly specified.

Setting consistent defaults makes tests more predictable and simplifies test setup. Factories still allow overriding these defaults when necessary.