### PR TITLE
Fixes bug in SU calculations

### DIFF
--- a/keystone_api/apps/allocations/factories.py
+++ b/keystone_api/apps/allocations/factories.py
@@ -179,7 +179,7 @@ class AllocationFactory(DjangoModelFactory):
         if not is_approved:
             return None
 
-        is_expired = self.request.expire <= date.today()
+        is_expired = (self.request.expire is not None) and (self.request.expire <= date.today())
         if is_approved and is_expired:
             return randgen.randint(0, self.awarded // 100) * 100
 

--- a/keystone_api/apps/allocations/managers.py
+++ b/keystone_api/apps/allocations/managers.py
@@ -9,7 +9,7 @@ associated model class called `objects`.
 from datetime import date
 from typing import TYPE_CHECKING
 
-from django.db.models import Manager, QuerySet, Sum
+from django.db.models import Manager, Q, QuerySet, Sum
 
 from apps.users.models import Team
 
@@ -53,7 +53,9 @@ class AllocationManager(Manager):
         """
 
         return self.approved_allocations(account, cluster).filter(
-            request__active__lte=date.today(), request__expire__gt=date.today()
+            request__active__lte=date.today()
+        ).filter(
+            Q(request__expire__gt=date.today()) | Q(request__expire__isnull=True)
         )
 
     def expiring_allocations(self, account: Team, cluster: 'Cluster') -> QuerySet:

--- a/keystone_api/apps/allocations/models.py
+++ b/keystone_api/apps/allocations/models.py
@@ -42,7 +42,11 @@ class TeamModelInterface:
 
 @auditlog.register()
 class Allocation(TeamModelInterface, models.Model):
-    """User service unit allocation."""
+    """User service unit allocation.
+
+    Allocations are marked as "expired" when their `final` field is populated.
+    If this field is `None`, the allocation has yet been processed as "expired".
+    """
 
     class Meta:
         """Database model settings."""

--- a/keystone_api/apps/allocations/tests/test_managers/test_AllocationManager.py
+++ b/keystone_api/apps/allocations/tests/test_managers/test_AllocationManager.py
@@ -6,114 +6,515 @@ from django.test import TestCase
 from django.utils import timezone
 
 from apps.allocations.factories import AllocationFactory, AllocationRequestFactory, ClusterFactory
-from apps.allocations.models import *
-from apps.users.factories import TeamFactory, UserFactory
+from apps.allocations.models import Allocation
+from apps.users.factories import TeamFactory
 
 
-class GetAllocationData(TestCase):
-    """Test getter methods used to retrieve allocation metadata/status."""
+class ApprovedAllocationsMethod(TestCase):
+    """Test the fetching of approved allocations."""
 
     def setUp(self) -> None:
-        """Create test data."""
+        """Instantiate common test fixtures."""
 
         self.team = TeamFactory()
         self.cluster = ClusterFactory()
 
-        # An allocation request pending review
-        self.request_pending = AllocationRequestFactory(
-            team=self.team,
-            status='PD',
-            active=timezone.now().date(),
-            expire=timezone.now().date() + timedelta(days=30)
-        )
-        self.allocation_pending = AllocationFactory(
-            requested=100,
-            awarded=80,
-            final=None,
+    def test_includes_active_approved_allocations(self) -> None:
+        """Verify active, approved allocations are included in the returned query."""
+
+        allocation = AllocationFactory(
             cluster=self.cluster,
-            request=self.request_pending
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date(),
+                expire=timezone.now().date() + timedelta(days=30),
+            )
         )
 
-        # An approved allocation request that is active
-        self.request_active = AllocationRequestFactory(
-            team=self.team,
-            status='AP',
-            active=timezone.now().date(),
-            expire=timezone.now().date() + timedelta(days=30)
-        )
-        self.allocation_active = AllocationFactory(
-            requested=100,
-            awarded=80,
-            final=None,
+        results = Allocation.objects.approved_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_includes_expired_approved_allocations(self) -> None:
+        """Verify expired, approved allocations are included in the returned query."""
+
+        allocation = AllocationFactory(
             cluster=self.cluster,
-            request=self.request_active
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=60),
+                expire=timezone.now().date() - timedelta(days=30),
+            )
         )
 
-        # An approved allocation request that is expired without final usage
-        self.request_expired = AllocationRequestFactory(
-            team=self.team,
-            status='AP',
-            active=timezone.now().date() - timedelta(days=60),
-            expire=timezone.now().date() - timedelta(days=30)
+        results = Allocation.objects.approved_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_includes_upcoming_approved_allocations(self) -> None:
+        """Verify upcoming, approved allocations are included in the returned query."""
+
+        allocation = AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() + timedelta(days=30),
+                expire=timezone.now().date() + timedelta(days=60),
+            )
         )
-        self.allocation_expired = AllocationFactory(
-            requested=100,
+
+        results = Allocation.objects.approved_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_includes_approved_allocations_with_no_dates(self) -> None:
+        """Verify allocations with no start/end date are included in the returned query."""
+
+        allocation = AllocationFactory(
+            cluster=self.cluster,
+            final=None,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=None, expire=None
+            )
+        )
+
+        results = Allocation.objects.approved_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_excludes_pending_allocations(self) -> None:
+        """Verify pending allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="PD",
+                active=timezone.now().date(),
+                expire=timezone.now().date() + timedelta(days=30),
+            )
+        )
+
+        results = Allocation.objects.approved_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+
+class ActiveAllocationsMethod(TestCase):
+    """Test the fetching of active allocations."""
+
+    def setUp(self) -> None:
+        """Instantiate common test fixtures."""
+
+        self.team = TeamFactory()
+        self.cluster = ClusterFactory()
+
+    def test_includes_active_approved_allocations(self) -> None:
+        """Verify currently active allocations are included in the returned query."""
+
+        allocation = AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=30),
+                expire=timezone.now().date() + timedelta(days=30),
+            )
+        )
+
+        results = Allocation.objects.active_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_excludes_expired_approved_allocations(self) -> None:
+        """Verify expired, approved allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=60),
+                expire=timezone.now().date() - timedelta(days=30),  # expired
+            )
+        )
+
+        results = Allocation.objects.active_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+    def test_excludes_upcoming_approved_allocations(self) -> None:
+        """Verify upcoming, approved allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() + timedelta(days=30),  # future start
+                expire=timezone.now().date() + timedelta(days=60),
+            )
+        )
+
+        results = Allocation.objects.active_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+    def test_includes_approved_allocations_with_no_expiration(self) -> None:
+        """Verify allocations with no end date are included in the returned query."""
+
+        allocation = AllocationFactory(
+            cluster=self.cluster,
+            final=None,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=60),
+                expire=None,
+            )
+        )
+
+        results = Allocation.objects.active_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_excludes_pending_allocations(self) -> None:
+        """Verify pending allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="PD",
+                active=timezone.now().date() - timedelta(days=30),
+                expire=timezone.now().date() + timedelta(days=30),
+            )
+        )
+
+        results = Allocation.objects.active_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+
+class ExpiringAllocationsMethod(TestCase):
+    """Test the fetching of expiring allocations."""
+
+    def setUp(self) -> None:
+        """Instantiate common test fixtures."""
+
+        self.team = TeamFactory()
+        self.cluster = ClusterFactory()
+
+    def test_includes_expiring_allocations(self) -> None:
+        """Verify expiring allocations are included in the returned query."""
+
+        allocation = AllocationFactory(
+            cluster=self.cluster,
+            final=None,  # None signifies the expiration has not been processed yet
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=60),
+                expire=timezone.now().date() - timedelta(days=30),  # past expiration
+            )
+        )
+
+        results = Allocation.objects.expiring_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([allocation], results, ordered=False)
+
+    def test_excludes_allocations_with_final_usage(self) -> None:
+        """Verify expired allocations with a known final usage are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            final=0,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=60),
+                expire=timezone.now().date() - timedelta(days=30),  # past expiration
+            )
+        )
+
+        results = Allocation.objects.expiring_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+    def test_excludes_active_approved_allocations(self) -> None:
+        """Verify active, approved allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() - timedelta(days=30),
+                expire=timezone.now().date() + timedelta(days=30),  # still active
+            )
+        )
+
+        results = Allocation.objects.expiring_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+    def test_excludes_upcoming_approved_allocation(self) -> None:
+        """Verify upcoming, approved allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=timezone.now().date() + timedelta(days=30),  # not started yet
+                expire=timezone.now().date() + timedelta(days=60),
+            )
+        )
+
+        results = Allocation.objects.expiring_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+    def test_excludes_pending_request(self) -> None:
+        """Verify pending allocations are not included in the returned query."""
+
+        AllocationFactory(
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="PD",  # not approved
+                active=timezone.now().date() - timedelta(days=60),
+                expire=timezone.now().date() - timedelta(days=30),
+            )
+        )
+
+        results = Allocation.objects.expiring_allocations(self.team, self.cluster)
+        self.assertQuerySetEqual([], results, ordered=False)
+
+
+class ActiveServiceUnitsMethod(TestCase):
+    """Test the calculation of active service units."""
+
+    def setUp(self) -> None:
+        """Instantiate test fixtures covering multiple edge cases."""
+
+        self.team = TeamFactory()
+        self.cluster = ClusterFactory()
+
+        today = timezone.now().date()
+
+        # Active, approved allocation (included)
+        self.active_allocation = AllocationFactory(
+            awarded=80,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today,
+                expire=today + timedelta(days=30),
+            )
+        )
+
+        # Expired allocation (excluded)
+        AllocationFactory(
+            awarded=50,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=60),
+                expire=today - timedelta(days=30),
+            )
+        )
+
+        # Upcoming allocation (excluded)
+        AllocationFactory(
+            awarded=40,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today + timedelta(days=5),
+                expire=today + timedelta(days=40),
+            )
+        )
+
+        # Active with no expiration (included)
+        self.no_expire_allocation = AllocationFactory(
+            awarded=20,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=10),
+                expire=None,
+            )
+        )
+
+        # Pending request (excluded)
+        AllocationFactory(
+            awarded=30,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="PD",
+                active=today,
+                expire=today + timedelta(days=30),
+            )
+        )
+
+    def test_service_unit_calculation(self) -> None:
+        """Verify active service units only sum from currently active, approved allocations."""
+
+        expected_su = sum(a.awarded for a in [self.active_allocation, self.no_expire_allocation])
+        returned_su = Allocation.objects.active_service_units(self.team, self.cluster)
+        self.assertEqual(expected_su, returned_su)
+
+
+class ExpiringServiceUnitsMethod(TestCase):
+    """Test the calculation of expiring service units."""
+
+    def setUp(self) -> None:
+        """Instantiate test fixtures covering multiple edge cases."""
+
+        self.team = TeamFactory()
+        self.cluster = ClusterFactory()
+
+        today = timezone.now().date()
+
+        # Expiring allocation - not yet processed (included)
+        self.expiring_allocation = AllocationFactory(
             awarded=70,
             final=None,
             cluster=self.cluster,
-            request=self.request_expired
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=60),
+                expire=today - timedelta(days=30),
+            )
         )
 
-        # An approved allocation request that is expired with final usage
-        self.request4 = AllocationRequestFactory(
-            team=self.team,
-            status='AP',
-            active=timezone.now().date() - timedelta(days=30),
-            expire=timezone.now().date()
-        )
-        self.allocation4 = AllocationFactory(
-            requested=100,
+        # Expired allocation - already processed (excluded)
+        self.expired_allocation = AllocationFactory(
             awarded=60,
-            final=60,
+            final=10,
             cluster=self.cluster,
-            request=self.request4
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=60),
+                expire=today - timedelta(days=30),
+            )
         )
 
-    def test_approved_allocations(self) -> None:
-        """Verify the `approved_allocations` method returns only approved allocations."""
+        # Active allocation (excluded)
+        AllocationFactory(
+            awarded=50,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=10),
+                expire=today + timedelta(days=20),
+            )
+        )
 
-        approved_allocations = Allocation.objects.approved_allocations(self.team, self.cluster)
-        expected_allocations = [self.allocation_active, self.allocation_expired, self.allocation4]
-        self.assertQuerySetEqual(expected_allocations, approved_allocations, ordered=False)
+        # Upcoming allocation (excluded)
+        AllocationFactory(
+            awarded=40,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today + timedelta(days=5),
+                expire=today + timedelta(days=40),
+            )
+        )
 
-    def test_active_allocations(self) -> None:
-        """Verify the `active_allocations` method returns only active allocations."""
+        # Pending request (excluded)
+        AllocationFactory(
+            awarded=30,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="PD",
+                active=today - timedelta(days=60),
+                expire=today - timedelta(days=30),
+            )
+        )
 
-        active_allocations = Allocation.objects.active_allocations(self.team, self.cluster)
-        expected_allocations = [self.allocation_active]
-        self.assertQuerySetEqual(expected_allocations, active_allocations, ordered=False)
+        # Active with no expiration (excluded)
+        AllocationFactory(
+            awarded=20,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=10),
+                expire=None,
+            )
+        )
 
-    def test_expired_allocations(self) -> None:
-        """Verify the `expired_allocations` method returns only expired allocations."""
+    def test_service_unit_calculation(self) -> None:
+        """Verify expiring service units only sum from expiring, approved allocations."""
 
-        expiring_allocations = Allocation.objects.expiring_allocations(self.team, self.cluster)
-        expected_allocations = [self.allocation_expired]
-        self.assertQuerySetEqual(expected_allocations, expiring_allocations, ordered=False)
+        expected_su = sum(a.awarded for a in [self.expiring_allocation])
+        returned_su = Allocation.objects.expiring_service_units(self.team, self.cluster)
+        self.assertEqual(expected_su, returned_su)
 
-    def test_active_service_units(self) -> None:
-        """Verify the `active_service_units` method returns the total awarded service units for active allocations."""
 
-        active_su = Allocation.objects.active_service_units(self.team, self.cluster)
-        self.assertEqual(80, active_su)
+class HistoricalUsageMethod(TestCase):
+    """Test the calculation of historical service units."""
 
-    def test_expired_service_units(self) -> None:
-        """Verify the `expired_service_units` method returns the total awarded service units for expired allocations."""
+    def setUp(self) -> None:
+        """Instantiate test fixtures covering multiple edge cases."""
 
-        expiring_su = Allocation.objects.expiring_service_units(self.team, self.cluster)
-        self.assertEqual(70, expiring_su)
+        self.team = TeamFactory()
+        self.cluster = ClusterFactory()
 
-    def test_historical_usage(self) -> None:
-        """Verify the `historical_usage` method returns the total final usage for expired allocations."""
+        today = timezone.now().date()
 
-        historical_usage = Allocation.objects.historical_usage(self.team, self.cluster)
-        self.assertEqual(60, historical_usage)
+        # Expired allocation with final usage (included)
+        self.expired_with_final = AllocationFactory(
+            final=60,
+            awarded=70,  # awarded doesn't matter here
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=60),
+                expire=today - timedelta(days=30),
+            )
+        )
+
+        # Expired allocation without final usage (excluded)
+        AllocationFactory(
+            final=None,
+            awarded=50,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=90),
+                expire=today - timedelta(days=60),
+            )
+        )
+
+        # Active allocation (excluded)
+        AllocationFactory(
+            final=None,
+            awarded=80,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=10),
+                expire=today + timedelta(days=20),
+            )
+        )
+
+        # Upcoming allocation (excluded)
+        AllocationFactory(
+            final=None,
+            awarded=40,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today + timedelta(days=5),
+                expire=today + timedelta(days=40),
+            )
+        )
+
+        # Pending allocation (excluded)
+        AllocationFactory(
+            final=None,
+            awarded=30,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="PD",
+                active=today - timedelta(days=60),
+                expire=today - timedelta(days=30),
+            )
+        )
+
+        # Active allocation with no expiration (excluded)
+        AllocationFactory(
+            final=None,
+            awarded=20,
+            cluster=self.cluster,
+            request=AllocationRequestFactory(
+                team=self.team, status="AP",
+                active=today - timedelta(days=10),
+                expire=None,
+            )
+        )
+
+    def test_service_unit_calculation(self) -> None:
+        """Verify historical usage only sums the final values of expired allocations."""
+
+        expected_usage = sum(a.final for a in [self.expired_with_final])
+        returned_usage = Allocation.objects.historical_usage(self.team, self.cluster)
+        self.assertEqual(expected_usage, returned_usage)


### PR DESCRIPTION
Fixes a bug  where approved allocations without expiration dates are not included in awarded SUs applied to slurm accounts. This is an important calculation, so I added fairly extensive tests to cover various edge cases.