### PR TITLE
Update render_template command to use user templates by default

### DIFF
--- a/keystone_api/apps/notifications/management/commands/render_templates.py
+++ b/keystone_api/apps/notifications/management/commands/render_templates.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
         parser.add_argument('--templates',
             type=Path,
-            default=settings.EMAIL_DEFAULT_DIR,
+            default=settings.EMAIL_TEMPLATE_DIR,
             help='An optional directory of custom HTML templates to render.')
 
     def handle(self, *args, **options) -> None:


### PR DESCRIPTION
The `--templates` argument in the `render_template` command was defaulting to the built-in templates, when it should be defaulting to the user provided templates. This doesn't cause any problems when a use manually provides an argument, but is a confusing default behavior. 