### PR TITLE
Supports variability in slurm job formatting

### DIFF
--- a/keystone_api/plugins/slurm.py
+++ b/keystone_api/plugins/slurm.py
@@ -3,11 +3,8 @@
 import logging
 import re
 from datetime import datetime, timedelta
-from multiprocessing.pool import job_counter
 from shlex import split
 from subprocess import PIPE, Popen
-
-from scout_apm.rq import job_instrumented
 
 log = logging.getLogger(__name__)
 

--- a/keystone_api/plugins/slurm.py
+++ b/keystone_api/plugins/slurm.py
@@ -3,8 +3,11 @@
 import logging
 import re
 from datetime import datetime, timedelta
+from multiprocessing.pool import job_counter
 from shlex import split
 from subprocess import PIPE, Popen
+
+from scout_apm.rq import job_instrumented
 
 log = logging.getLogger(__name__)
 
@@ -218,6 +221,9 @@ def get_cluster_usage(account_name: str, cluster_name: str) -> int:
 def get_cluster_jobs(cluster_name: str) -> list[dict]:
     """Retrieve SLURM job information for a given cluster.
 
+    This function returns data as presented by Slurm with no manipulation
+    except typecasting common data types (int, date, etc.) into Python types.
+
     Args:
         cluster_name: Name of the SLURM cluster to query jobs for.
 
@@ -233,17 +239,20 @@ def get_cluster_jobs(cluster_name: str) -> list[dict]:
     )
 
     cmd = split(
-        f"sacct --allusers --allocations --noheader --parsable2 "
+        f"sacct --allusers --allocations --parsable2 "
         f"--clusters={cluster_name} --format={','.join(fields)}"
     )
 
+    header_row, *job_rows = subprocess_call(cmd).splitlines()
+    header_values = [col_name.lower() for col_name in header_row.split()]
+
     job_list = []
-    for line in subprocess_call(cmd).splitlines():
-        parsed_line = line.split('|')
-        job_data: dict[str, any] = {field.lower(): value for field, value in zip(fields, parsed_line)}
+    for row in job_rows:
+        job_values = row.split('|')
+        job_data: dict[str, any] = {col_name: value for col_name, value in zip(header_values, job_values)}
 
         # Cast select values into Python objects
-        job_data['priority'] = int(job_data['priority']) if job_data['priority'] else None
+        job_data['priority'] = int(job_data['priority']) if job_data.get('priority') else None
         job_data['submit'] = parse_slurm_date(job_data['submit'])
         job_data['start'] = parse_slurm_date(job_data['start'])
         job_data['end'] = parse_slurm_date(job_data['end'])


### PR DESCRIPTION
A production system reported an inability to parse Slurm job data for a few hours. Unfortunately, this error was short lived and can't be reproduced anymore. The traceback seems to indicate that a column was not included in the outputted Slurm table. This PR updates the parsing logic to explicitly check for the returned column names instead of assuming the match a specific format.

Traceback:

```

Traceback (most recent call last):
File ".../python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
R = retval = fun(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^
File ".../python3.11/site-packages/celery/app/trace.py", line 736, in __protected_call__
return self.run(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^
File ".../python3.11/site-packages/keystone_api/apps/allocations/tasks/jobstats.py", line 38, in slurm_update_job_stats_for_cluster
cluster_jobs = get_cluster_jobs(cluster.name)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File ".../python3.11/site-packages/keystone_api/plugins/slurm.py", line 246, in get_cluster_jobs
job_data['priority'] = int(job_data['priority']) if job_data['priority'] else None
~~~~~~~~^^^^^^^^^^^^
KeyError: 'priority'
```