### PR TITLE
Filters returned comments based on `private` field

### DIFF
--- a/keystone_api/apps/allocations/factories.py
+++ b/keystone_api/apps/allocations/factories.py
@@ -229,15 +229,18 @@ class AttachmentFactory(DjangoModelFactory):
 
 
 class CommentFactory(DjangoModelFactory):
-    """Factory for creating mock `Comment` instances."""
+    """Factory for creating mock `Comment` instances.
+
+    Comments default to being public (`private=False`).
+    """
 
     class Meta:
         """Factory settings."""
 
         model = Comment
 
+    private = False
     content = factory.Faker('sentence', nb_words=10)
-    private = factory.Faker('pybool', truth_probability=10)
 
     user = factory.SubFactory(UserFactory)
     request = factory.SubFactory(AllocationRequestFactory)

--- a/keystone_api/apps/allocations/permissions.py
+++ b/keystone_api/apps/allocations/permissions.py
@@ -66,6 +66,8 @@ class AllocationRequestPermissions(PermissionUtils, permissions.BasePermission):
         if self.user_is_staff(request) or self.is_read_only(request):
             return True
 
+        # For create/update: only allow if user is privileged member of the target team.
+        # Deny creation if team can't be resolved.
         try:
             team_id = request.data.get('team')
             team = Team.objects.get(pk=team_id)
@@ -78,6 +80,7 @@ class AllocationRequestPermissions(PermissionUtils, permissions.BasePermission):
     def has_object_permission(self, request: Request, view: View, obj: AllocationRequest) -> bool:
         """Return whether the incoming HTTP request has permission to access a database record."""
 
+        # Allow if staff or if user is a team member accessing via a read-only method.
         return self.user_is_staff(request) or (self.is_read_only(request) and self.user_in_team(request, obj))
 
 
@@ -114,6 +117,8 @@ class CommentPermissions(PermissionUtils, permissions.BasePermission):
         if self.user_is_staff(request) or self.is_read_only(request):
             return True
 
+        # For create/update: only allow if user is in the target allocation's team.
+        # Deny creation if allocation request can't be resolved.
         try:
             alloc_request_id = request.data.get('request')
             alloc_request = AllocationRequest.objects.get(pk=alloc_request_id)

--- a/keystone_api/apps/allocations/permissions.py
+++ b/keystone_api/apps/allocations/permissions.py
@@ -124,10 +124,10 @@ class CommentPermissions(PermissionUtils, permissions.BasePermission):
 
         return not self.is_create(view) or request.user in team.get_all_members()
 
-    def has_object_permission(self, request: Request, view: View, obj: TeamModelInterface) -> bool:
+    def has_object_permission(self, request: Request, view: View, obj: Comment) -> bool:
         """Return whether the incoming HTTP request has permission to access a database record."""
 
-        return self.user_is_staff(request) or self.user_in_team(request, obj)
+        return self.user_is_staff(request) or (self.user_in_team(request, obj) and not obj.private)
 
 
 class MemberReadOnly(PermissionUtils, permissions.BasePermission):

--- a/keystone_api/apps/allocations/tests/test_serializers/test_CommentSerializer.py
+++ b/keystone_api/apps/allocations/tests/test_serializers/test_CommentSerializer.py
@@ -1,0 +1,196 @@
+"""Unit tests for the `CommentSerializer` class."""
+
+from django.test import RequestFactory, TestCase
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+
+from apps.allocations.factories import AllocationRequestFactory
+from apps.allocations.models import Comment
+from apps.allocations.serializers import CommentSerializer
+from apps.users.factories import UserFactory
+
+
+class CommentSerializerValidationTests(TestCase):
+    """Unit tests for CommentSerializer private field validation."""
+
+    def setUp(self) -> None:
+        """Initialize test fixtures."""
+
+        self.normal_user = UserFactory()
+        self.staff_user = UserFactory(is_staff=True)
+        self.alloc_request = AllocationRequestFactory()
+
+    @staticmethod
+    def _user_post_request(user) -> Request:
+        """Create an HTTP request originating from the given user.
+
+        Args:
+            user: The user to create the request from.
+
+        Returns:
+            An HTTP POST request against the `/dummy/` endpoint.
+        """
+
+        drf_request = Request(RequestFactory().post('/dummy/'))
+        drf_request.user = user
+        return drf_request
+
+    def test_non_staff_create_private(self) -> None:
+        """Verify non-staff users cannot create comments with `private=True`."""
+
+        request = self._user_post_request(self.normal_user)
+        data = {
+            'request': self.alloc_request.pk,
+            'user': self.normal_user.pk,
+            'private': True,
+            'content': 'User private comment'
+        }
+
+        serializer = CommentSerializer(data=data, context={'request': request})
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_staff_create_private(self) -> None:
+        """Verify staff users can create comments with `private=True`."""
+
+        request = self._user_post_request(self.staff_user)
+        data = {
+            'request': self.alloc_request.pk,
+            'user': self.staff_user.pk,
+            'private': True,
+            'content': 'Staff private comment'
+        }
+
+        serializer = CommentSerializer(data=data, context={'request': request})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_non_staff_update_to_private(self) -> None:
+        """Verify non-staff users cannot update the `private` field from `False` to `True`."""
+
+        # Initialize a public comment
+        comment = Comment.objects.create(
+            request=self.alloc_request,
+            user=self.normal_user,
+            private=False,
+            content='Original comment'
+        )
+
+        # Update a comment to private
+        data = {'private': True}
+        serializer = CommentSerializer(
+            instance=comment,
+            data=data,
+            partial=True,
+            context={'request': self._user_post_request(self.normal_user)}
+        )
+
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_non_staff_update_to_public(self) -> None:
+        """Verify non-staff users cannot update the `private` field from `True` to `False`."""
+
+        # Initialize a private comment
+        comment = Comment.objects.create(
+            request=self.alloc_request,
+            user=self.normal_user,
+            private=True,
+            content='Staff private'
+        )
+
+        # Update a comment to public
+        data = {'private': False}
+        serializer = CommentSerializer(
+            instance=comment,
+            data=data,
+            partial=True,
+            context={'request': self._user_post_request(self.normal_user)}
+        )
+
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_staff_update_to_private(self) -> None:
+        """Verify staff users can update the `private` field from `False` to `True`."""
+
+        # Initialize a public comment
+        comment = Comment.objects.create(
+            request=self.alloc_request,
+            user=self.staff_user,
+            private=False,
+            content='Original comment'
+        )
+
+        # Update a comment to private
+        data = {'private': True}
+        serializer = CommentSerializer(
+            instance=comment,
+            data=data,
+            partial=True,
+            context={'request': self._user_post_request(self.staff_user)}
+        )
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+
+    def test_staff_update_set_public(self) -> None:
+        """Verify staff users can update the `private` field from `True` to `False`."""
+
+        # Initialize a private comment
+        comment = Comment.objects.create(
+            request=self.alloc_request,
+            user=self.staff_user,
+            private=True,
+            content='Staff private'
+        )
+
+        # Update a comment to public
+        data = {'private': False}
+        serializer = CommentSerializer(
+            instance=comment,
+            data=data,
+            partial=True,
+            context={'request': self._user_post_request(self.staff_user)}
+        )
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+
+    def test_non_staff_update_private_content(self) -> None:
+        """Verify non-staff users cannot update comment contents when `private=True`."""
+
+        comment = Comment.objects.create(
+            request=self.alloc_request,
+            user=self.normal_user,
+            private=True,
+            content='Staff private'
+        )
+
+        data = {'content': "This is new content"}
+        serializer = CommentSerializer(
+            instance=comment,
+            data=data,
+            partial=True,
+            context={'request': self._user_post_request(self.normal_user)}
+        )
+
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_staff_update_private_content(self) -> None:
+        """Verify staff users can update comment contents when `private=True`."""
+
+        comment = Comment.objects.create(
+            request=self.alloc_request,
+            user=self.staff_user,
+            private=True,
+            content='Staff private'
+        )
+
+        data = {'content': "This is new content"}
+        serializer = CommentSerializer(
+            instance=comment,
+            data=data,
+            partial=True,
+            context={'request': self._user_post_request(self.staff_user)}
+        )
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))

--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -6,7 +6,7 @@ serve as the controller layer in Django's MVC-inspired architecture, bridging
 URLs to business logic.
 """
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, QuerySet
 from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 from rest_framework import serializers, status, viewsets
 from rest_framework.generics import GenericAPIView
@@ -371,6 +371,17 @@ class CommentViewSet(TeamScopedListMixin, viewsets.ModelViewSet):
         'request',
         'user'
     )
+
+    def get_queryset(self) -> QuerySet:
+        """Return the base queryset filtered by user team membership for list actions."""
+
+        queryset = super().get_queryset()
+
+        # Only include private comments for admin users
+        if self.action == 'list' and not self.request.user.is_staff:
+            return queryset.filter(private=False)
+
+        return queryset
 
 
 @extend_schema_view(

--- a/keystone_api/apps/users/mixins.py
+++ b/keystone_api/apps/users/mixins.py
@@ -5,17 +5,11 @@ Each mixin defines a single, isolated piece of functionality and can be
 combined with other mixins or base view classes as needed.
 """
 
-from typing import TypeVar
-
-from rest_framework.request import Request
-from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
+from django.db.models import QuerySet
 
 from .models import Team
 
 __all__ = ['TeamScopedListMixin', 'UserScopedListMixin']
-
-TViewSet = TypeVar("TViewSet", bound=GenericViewSet)
 
 
 class TeamScopedListMixin:
@@ -29,21 +23,15 @@ class TeamScopedListMixin:
     # Can be overwritten by subclasses to match the relevant ForeignKey field in a request.
     team_field = 'team'
 
-    def list(self: TViewSet, request: Request) -> Response:
-        """Return a list of serialized records filtered by user team permissions."""
+    def get_queryset(self) -> QuerySet:
+        """Return the base queryset filtered by user team membership for list actions."""
 
-        queryset = self.filter_queryset(self.get_queryset())
-        if not request.user.is_staff:
-            teams = Team.objects.teams_for_user(request.user)
-            queryset = queryset.filter(**{self.team_field + '__in': teams})
+        queryset = super().get_queryset()
+        if self.action == 'list' and not self.request.user.is_staff:
+            teams = Team.objects.teams_for_user(self.request.user)
+            return queryset.filter(**{f'{self.team_field}__in': teams})
 
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
+        return queryset
 
 
 class UserScopedListMixin:
@@ -58,18 +46,11 @@ class UserScopedListMixin:
     # Can be overwritten by subclasses to match the relevant ForeignKey field in a request.
     user_field = 'user'
 
-    def list(self: TViewSet, request: Request, *args, **kwargs) -> Response:
-        """Return a list of serialized records filtered for the requesting user."""
+    def get_queryset(self) -> QuerySet:
+        """Return the base queryset filtered by the requesting user for list actions."""
 
-        queryset = self.filter_queryset(self.get_queryset())
+        queryset = super().get_queryset()
+        if self.action == 'list' and not self.request.user.is_staff:
+            return queryset.filter(**{self.user_field: self.request.user})
 
-        if not request.user.is_staff:
-            queryset = queryset.filter(**{self.user_field: request.user})
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
+        return queryset

--- a/keystone_api/tests/allocations/test_allocations.py
+++ b/keystone_api/tests/allocations/test_allocations.py
@@ -5,7 +5,7 @@ from rest_framework.test import APITestCase
 
 from apps.allocations.factories import AllocationFactory
 from apps.users.factories import UserFactory
-from tests.utils import CustomAsserts, TeamScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, TeamListFilteringTestMixin
 
 
 class EndpointPermissions(APITestCase, CustomAsserts):
@@ -78,7 +78,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         )
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     endpoint = '/allocations/allocations/'

--- a/keystone_api/tests/allocations/test_attachments.py
+++ b/keystone_api/tests/allocations/test_attachments.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITestCase
 
 from apps.allocations.factories import AttachmentFactory
 from apps.users.factories import UserFactory
-from tests.utils import CustomAsserts, TeamScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, TeamListFilteringTestMixin
 
 
 class EndpointPermissions(APITestCase, CustomAsserts):
@@ -81,7 +81,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         )
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     endpoint = '/allocations/attachments/'

--- a/keystone_api/tests/allocations/test_comments.py
+++ b/keystone_api/tests/allocations/test_comments.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITestCase
 from apps.allocations.factories import AllocationRequestFactory, CommentFactory
 from apps.users.factories import MembershipFactory, UserFactory
 from apps.users.models import Membership
-from tests.utils import CustomAsserts, TeamScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, TeamListFilteringTestMixin
 
 
 class EndpointPermissions(APITestCase, CustomAsserts):
@@ -143,7 +143,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         )
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     endpoint = '/allocations/comments/'

--- a/keystone_api/tests/allocations/test_comments_pk.py
+++ b/keystone_api/tests/allocations/test_comments_pk.py
@@ -24,6 +24,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     | Team owner                    | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
     | Staff user                    | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
     | Team member (private comment) | 403 | 403  | 200     | 405  | 403 | 403   | 403    | 405   |
+    | Team owner (private comment)  | 403 | 403  | 200     | 405  | 403 | 403   | 403    | 405   |
     | Staff user  (private comment) | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
     """
 
@@ -162,6 +163,22 @@ class EndpointPermissions(APITestCase, CustomAsserts):
 
     def test_team_member_private_permissions(self) -> None:
         """Verify team members cannot access private comments."""
+
+        self.client.force_authenticate(user=self.team_member)
+        self.assert_http_responses(
+            self.private_endpoint,
+            get=status.HTTP_403_FORBIDDEN,
+            head=status.HTTP_403_FORBIDDEN,
+            options=status.HTTP_200_OK,
+            post=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put=status.HTTP_403_FORBIDDEN,
+            patch=status.HTTP_403_FORBIDDEN,
+            delete=status.HTTP_403_FORBIDDEN,
+            trace=status.HTTP_405_METHOD_NOT_ALLOWED
+        )
+
+    def test_team_owner_private_permissions(self) -> None:
+        """Verify team owners cannot access private comments."""
 
         self.client.force_authenticate(user=self.team_member)
         self.assert_http_responses(

--- a/keystone_api/tests/allocations/test_comments_pk.py
+++ b/keystone_api/tests/allocations/test_comments_pk.py
@@ -3,7 +3,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.allocations.factories import CommentFactory
+from apps.allocations.factories import AllocationRequestFactory, CommentFactory
 from apps.users.factories import MembershipFactory, UserFactory
 from apps.users.models import Membership
 from tests.utils import CustomAsserts
@@ -15,14 +15,16 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     Endpoint permissions are tested against the following matrix of HTTP responses.
     Permissions depend on the user's role within the team owning the accessed record.
 
-    | User Status                | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
-    |----------------------------|-----|------|---------|------|-----|-------|--------|-------|
-    | Unauthenticated user       | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
-    | Authenticated non-member   | 403 | 403  | 200     | 405  | 403 | 403   | 403    | 405   |
-    | Team member                | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
-    | Team admin                 | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
-    | Team owner                 | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
-    | Staff user                 | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
+    | User Status                   | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
+    |-------------------------------|-----|------|---------|------|-----|-------|--------|-------|
+    | Unauthenticated user          | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
+    | Authenticated non-member      | 403 | 403  | 200     | 405  | 403 | 403   | 403    | 405   |
+    | Team member                   | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
+    | Team admin                    | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
+    | Team owner                    | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
+    | Staff user                    | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
+    | Team member (private comment) | 403 | 403  | 200     | 405  | 403 | 403   | 403    | 405   |
+    | Staff user  (private comment) | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
     """
 
     endpoint_pattern = '/allocations/comments/{pk}/'
@@ -30,18 +32,28 @@ class EndpointPermissions(APITestCase, CustomAsserts):
     def setUp(self) -> None:
         """Create test fixtures using mock data."""
 
-        self.comment = CommentFactory()
-        self.request = self.comment.request
+        # Create an allocation request to which comments will be assigned
+        self.request = AllocationRequestFactory()
 
+        # Create users with different levels of group membership/permissions
         self.team = self.request.team
         self.team_member = MembershipFactory(team=self.team, role=Membership.Role.MEMBER).user
         self.team_admin = MembershipFactory(team=self.team, role=Membership.Role.ADMIN).user
         self.team_owner = MembershipFactory(team=self.team, role=Membership.Role.OWNER).user
 
+        # Create non-team members
         self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
-        self.endpoint = self.endpoint_pattern.format(pk=self.comment.pk)
+        # Create a public comment
+        self.public_comment = CommentFactory(request=self.request)
+        self.endpoint = self.endpoint_pattern.format(pk=self.public_comment.pk)
+
+        # Create a public comment
+        self.private_comment = CommentFactory(private=True, request=self.request)
+        self.private_endpoint = self.endpoint_pattern.format(pk=self.private_comment.pk)
+
+        # Valid record data used to test write operations
         self.record_data = {'content': 'foobar', 'request': self.request.pk}
 
     def test_unauthenticated_user_permissions(self) -> None:
@@ -134,6 +146,40 @@ class EndpointPermissions(APITestCase, CustomAsserts):
 
         self.client.force_authenticate(user=self.staff_user)
 
+        self.assert_http_responses(
+            self.endpoint,
+            get=status.HTTP_200_OK,
+            head=status.HTTP_200_OK,
+            options=status.HTTP_200_OK,
+            post=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put=status.HTTP_200_OK,
+            patch=status.HTTP_200_OK,
+            delete=status.HTTP_204_NO_CONTENT,
+            trace=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put_body=self.record_data,
+            patch_data=self.record_data
+        )
+
+    def test_team_member_private_permissions(self) -> None:
+        """Verify team members cannot access private comments."""
+
+        self.client.force_authenticate(user=self.team_member)
+        self.assert_http_responses(
+            self.private_endpoint,
+            get=status.HTTP_403_FORBIDDEN,
+            head=status.HTTP_403_FORBIDDEN,
+            options=status.HTTP_200_OK,
+            post=status.HTTP_405_METHOD_NOT_ALLOWED,
+            put=status.HTTP_403_FORBIDDEN,
+            patch=status.HTTP_403_FORBIDDEN,
+            delete=status.HTTP_403_FORBIDDEN,
+            trace=status.HTTP_405_METHOD_NOT_ALLOWED
+        )
+
+    def test_staff_user_private_permissions(self) -> None:
+        """Verify staff members can access private comments."""
+
+        self.client.force_authenticate(user=self.staff_user)
         self.assert_http_responses(
             self.endpoint,
             get=status.HTTP_200_OK,

--- a/keystone_api/tests/allocations/test_jobs.py
+++ b/keystone_api/tests/allocations/test_jobs.py
@@ -5,7 +5,7 @@ from rest_framework.test import APITestCase
 
 from apps.allocations.factories import JobStatsFactory
 from apps.users.factories import UserFactory
-from tests.utils import CustomAsserts, TeamScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, TeamListFilteringTestMixin
 
 
 class EndpointPermissions(APITestCase, CustomAsserts):
@@ -77,7 +77,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         )
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     endpoint = '/allocations/jobs/'

--- a/keystone_api/tests/allocations/test_requests.py
+++ b/keystone_api/tests/allocations/test_requests.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITestCase
 from apps.allocations.factories import AllocationRequestFactory
 from apps.users.factories import MembershipFactory, UserFactory
 from apps.users.models import Membership
-from tests.utils import CustomAsserts, TeamScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, TeamListFilteringTestMixin
 
 
 class EndpointPermissions(APITestCase, CustomAsserts):
@@ -143,7 +143,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         )
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     endpoint = '/allocations/requests/'

--- a/keystone_api/tests/allocations/test_reviews.py
+++ b/keystone_api/tests/allocations/test_reviews.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITestCase
 from apps.allocations.factories import AllocationRequestFactory, AllocationReviewFactory
 from apps.allocations.models import AllocationReview
 from apps.users.factories import UserFactory
-from tests.utils import CustomAsserts, TeamScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, TeamListFilteringTestMixin
 
 ENDPOINT = '/allocations/reviews/'
 
@@ -136,7 +136,7 @@ class ReviewerAssignment(APITestCase):
         self.assertEqual('reviewer cannot be set to a different user than the submitter', response.data['reviewer'][0].lower())
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     endpoint = ENDPOINT

--- a/keystone_api/tests/notifications/test_notifications.py
+++ b/keystone_api/tests/notifications/test_notifications.py
@@ -5,7 +5,7 @@ from rest_framework.test import APITestCase
 
 from apps.notifications.factories import NotificationFactory
 from apps.users.factories import UserFactory
-from tests.utils import CustomAsserts, UserScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, UserListFilteringTestMixin
 
 ENDPOINT = '/notifications/notifications/'
 
@@ -78,7 +78,7 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         )
 
 
-class RecordFiltering(UserScopedListFilteringTestMixin, APITestCase):
+class UserRecordFiltering(UserListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user ownership."""
 
     endpoint = ENDPOINT

--- a/keystone_api/tests/notifications/test_preferences.py
+++ b/keystone_api/tests/notifications/test_preferences.py
@@ -5,7 +5,7 @@ from rest_framework.test import APITestCase
 
 from apps.notifications.factories import PreferenceFactory
 from apps.users.factories import UserFactory
-from tests.utils import CustomAsserts, UserScopedListFilteringTestMixin
+from tests.utils import CustomAsserts, UserListFilteringTestMixin
 
 ENDPOINT = '/notifications/preferences/'
 
@@ -128,7 +128,7 @@ class UserFieldAssignment(APITestCase):
         self.assertEqual(self.user2.id, response.data['user'])
 
 
-class RecordFiltering(UserScopedListFilteringTestMixin, APITestCase):
+class UserRecordFiltering(UserListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user ownership."""
 
     endpoint = ENDPOINT

--- a/keystone_api/tests/research/test_grants.py
+++ b/keystone_api/tests/research/test_grants.py
@@ -5,7 +5,7 @@ from datetime import date
 from rest_framework.test import APITestCase
 
 from apps.research_products.factories import GrantFactory
-from tests.utils import TeamScopedListFilteringTestMixin
+from tests.utils import TeamListFilteringTestMixin
 from .common import ResearchListEndpointPermissionsTestMixin
 
 
@@ -33,7 +33,7 @@ class EndpointPermissions(ResearchListEndpointPermissionsTestMixin, APITestCase)
         }
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     factory = GrantFactory

--- a/keystone_api/tests/research/test_publications.py
+++ b/keystone_api/tests/research/test_publications.py
@@ -5,7 +5,7 @@ import datetime
 from rest_framework.test import APITestCase
 
 from apps.research_products.factories import PublicationFactory
-from tests.utils import TeamScopedListFilteringTestMixin
+from tests.utils import TeamListFilteringTestMixin
 from .common import ResearchListEndpointPermissionsTestMixin
 
 
@@ -30,7 +30,7 @@ class EndpointPermissions(ResearchListEndpointPermissionsTestMixin, APITestCase)
         }
 
 
-class RecordFiltering(TeamScopedListFilteringTestMixin, APITestCase):
+class TeamRecordFiltering(TeamListFilteringTestMixin, APITestCase):
     """Test the filtering of returned records based on user team membership."""
 
     factory = PublicationFactory

--- a/keystone_api/tests/utils.py
+++ b/keystone_api/tests/utils.py
@@ -71,7 +71,7 @@ class CustomAsserts:
         return {name: value for name, value in zip(arg_names, arg_values) if value is not None}
 
 
-class TeamScopedListFilteringTestMixin(ABC):
+class TeamListFilteringTestMixin(ABC):
     """Test the filtering of returned records based on user team membership."""
 
     # Test configuration
@@ -141,7 +141,7 @@ class TeamScopedListFilteringTestMixin(ABC):
         self.assertEqual(0, len(response.json()))
 
 
-class UserScopedListFilteringTestMixin:
+class UserListFilteringTestMixin:
     """Test the filtering of returned records based on user ownership."""
 
     # Test configuration


### PR DESCRIPTION
Records marked private are now only returned to staff users. Non-staff users cannot view or edit records marked private.