### PR TITLE
Groups application logs under common docker dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,9 @@ RUN pip install --no-cache-dir /wheels/* && rm -rf /wheels
 RUN addgroup -g 121 keystone \
     && adduser -D -u 1001 -G keystone keystone \
     && mkdir -p /app/keystone /app/nginx \
-    && chown -R keystone:keystone /app /var/lib/nginx/
+    && chown -R keystone:keystone /app /var/lib/nginx \
+    && mkdir -p /var/lib/nginx/logs /var/log/nginx \
+    && chown -R keystone:keystone /var/lib/nginx /var/log/nginx
 
 # Switch to non-root user
 USER keystone

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Configure the application with container friendly defaults
-ENV CONFIG_UPLOAD_DIR=/app/media
-ENV CONFIG_STATIC_DIR=/app/static
-ENV DB_NAME=/app/keystone.db
-ENV LOG_APP_FILE=/app/keystone.log
+ENV CONFIG_UPLOAD_DIR=/app/keystone/media
+ENV CONFIG_STATIC_DIR=/app/keystone/static
+ENV DB_NAME=/app/keystone/keystone.db
+ENV LOG_APP_FILE=/app/keystone/keystone.log
 
 # Install runtime dependencies only
 RUN apk add --no-cache \

--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Ensure all processes are killed when the container terminates
+# Ensure all processes terminate when the container exits
 set -e
 trap "kill 0" INT TERM
 
-nginx  # Start nginx in background
+nginx -g 'daemon off;' -e /app/nginx/nginx.log &  # Start nginx in the background
 exec keystone-api "$@"  # Redirect commands to Keystone CLI

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -270,6 +270,7 @@ DATABASES = dict()
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 _db_name = env.str('DB_NAME', 'keystone')
+_db_path = (BASE_DIR / _db_name).with_suffix('.db')
 if env.bool('DB_POSTGRES_ENABLE', False):
     DATABASES['default'] = {
         'ENGINE': 'django_prometheus.db.backends.postgresql',
@@ -283,7 +284,7 @@ if env.bool('DB_POSTGRES_ENABLE', False):
 else:
     DATABASES['default'] = {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / f'{_db_name}.db',
+        'NAME': _db_path,
         'timeout': 30,
         'PRAGMA': {
             'journal_mode': 'wal',


### PR DESCRIPTION
This is a minor quality of life edit that ensures all keystone runtime files are stored in the docker container under `/app/keystone` and all nginx files under `/app/nginx`. It also fixes a few inconsistencies in file names and (nginx) log locations to make debugging the containerized application easier.