### PR TITLE
Fixes bad value splitting in Slurm job oarsing

### DIFF
--- a/keystone_api/apps/allocations/models.py
+++ b/keystone_api/apps/allocations/models.py
@@ -271,6 +271,7 @@ class Comment(TeamModelInterface, models.Model):
 class JobStats(TeamModelInterface, models.Model):
     """Slurm Job status and statistics."""
 
+    jobid = models.CharField(max_length=64, unique=True) # Slurm ID, not database ID
     account = models.CharField(max_length=128, null=True, blank=True)
     allocnodes = models.CharField(max_length=128, null=True, blank=True)
     alloctres = models.TextField(null=True, blank=True)
@@ -278,7 +279,6 @@ class JobStats(TeamModelInterface, models.Model):
     elapsed = models.DurationField(null=True, blank=True)
     end = models.DateTimeField(null=True, blank=True)
     group = models.CharField(max_length=128, null=True, blank=True)
-    jobid = models.CharField(max_length=64, unique=True)
     jobname = models.CharField(max_length=512, null=True, blank=True)
     nodelist = models.TextField(null=True, blank=True)
     priority = models.IntegerField(null=True, blank=True)

--- a/keystone_api/plugins/slurm.py
+++ b/keystone_api/plugins/slurm.py
@@ -14,7 +14,6 @@ __all__ = [
     'set_cluster_limit',
     'get_cluster_usage',
     'get_slurm_account_names',
-    'get_slurm_account_principal_investigator',
     'get_slurm_account_users',
     'parse_slurm_date',
     'parse_slurm_elapsed'
@@ -113,21 +112,6 @@ def get_slurm_account_names(cluster_name: str | None = None) -> set[str]:
         cmd.append(f"cluster={cluster_name}")
 
     return set(subprocess_call(cmd).split())
-
-
-def get_slurm_account_principal_investigator(account_name: str) -> str:
-    """Return the Principal Investigator (PI) username (Slurm account description field) for a Slurm account given the
-    account name
-
-    Args:
-        account_name: The Slurm account name
-
-    Returns:
-        The Slurm account PI username (description field)
-    """
-
-    cmd = split(f"sacctmgr show -nP account where account={account_name} format=Descr")
-    return subprocess_call(cmd)
 
 
 def get_slurm_account_users(account_name: str, cluster_name: str | None = None) -> set[str]:
@@ -229,32 +213,45 @@ def get_cluster_jobs(cluster_name: str) -> list[dict]:
     """
 
     # Field names to fetch from slurm and their returned order
-    fields = (
+    slurm_fields = (
         "Account", "AllocNodes", "AllocTres", "DerivedExitCode", "Elapsed",
         "End", "Group", "JobId", "JobName", "NodeList", "Priority",
         "Partition", "QOS", "Start", "State", "Submit", "User"
     )
 
-    cmd = split(
+    # Fetch job values from the Slurm account manager
+    slurm_cmd = split(
         f"sacct --allusers --allocations --parsable2 "
-        f"--clusters={cluster_name} --format={','.join(fields)}"
+        f"--clusters={cluster_name} --format={','.join(slurm_fields)}"
     )
 
-    header_row, *job_rows = subprocess_call(cmd).splitlines()
-    header_values = [col_name.lower() for col_name in header_row.split()]
+    # Parse header values from the output command
+    header_row, *job_rows = subprocess_call(slurm_cmd).splitlines()
+    header_values = [col_name.lower() for col_name in header_row.split("|")]
+
+    # Map field names to functions for casting values into Python types
+    cast_funcs = {
+        "submit": parse_slurm_date,
+        "start": parse_slurm_date,
+        "end": parse_slurm_date,
+        "elapsed": parse_slurm_elapsed,
+    }
 
     job_list = []
     for row in job_rows:
-        job_values = row.split('|')
-        job_data: dict[str, any] = {col_name: value for col_name, value in zip(header_values, job_values)}
+        # Parse values and cast to python types where appropriate
+        parsed_job = dict()
+        for header, val in zip(header_values, row.split("|")):
+            cast = cast_funcs.get(header)
+            if val and cast:
+                parsed_job[header] = cast(val)
 
-        # Cast select values into Python objects
-        job_data['priority'] = int(job_data['priority']) if job_data.get('priority') else None
-        job_data['submit'] = parse_slurm_date(job_data['submit'])
-        job_data['start'] = parse_slurm_date(job_data['start'])
-        job_data['end'] = parse_slurm_date(job_data['end'])
-        job_data['elapsed'] = parse_slurm_elapsed(job_data['elapsed'])
+            elif val:
+                parsed_job[header] = val
 
-        job_list.append(job_data)
+            else:
+                parsed_job[header] = None
+
+        job_list.append(parsed_job)
 
     return job_list


### PR DESCRIPTION
Keystone was parsing Slurm jobs using a call to `.split()` which should have been `.split("|")`. THis PR fixes the parsing error and also reworks the logic to be more robust against missing values.