### PR TITLE
Fixes bug where notification tests fail stochastically

### DIFF
--- a/keystone_api/apps/notifications/tests/tasks/test_upcoming_expirations.py
+++ b/keystone_api/apps/notifications/tests/tasks/test_upcoming_expirations.py
@@ -21,51 +21,56 @@ class ShouldNotifyUpcomingExpirationMethod(TestCase):
 
         mock_filter.return_value.exists.return_value = True
 
-        request = AllocationRequestFactory(expire=date.today() + timedelta(days=15))
-        PreferenceFactory(user=request.submitter, request_expiry_thresholds=[5])
+        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        request = AllocationRequestFactory(submitter=user, expire=date.today() + timedelta(days=15))
+        PreferenceFactory(user=user, request_expiry_thresholds=[5])
 
         self.assertFalse(
-            should_notify_upcoming_expiration(request.submitter, request)
+            should_notify_upcoming_expiration(user, request)
         )
 
     def test_true_if_new_notification(self) -> None:
         """Verify the return value is `True` if a notification threshold has been hit."""
 
-        request = AllocationRequestFactory(expire=date.today() + timedelta(days=5))
-        PreferenceFactory(user=request.submitter, request_expiry_thresholds=[15])
+        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        request = AllocationRequestFactory(submitter=user, expire=date.today() + timedelta(days=5))
+        PreferenceFactory(user=user, request_expiry_thresholds=[15])
 
         self.assertTrue(
-            should_notify_upcoming_expiration(request.submitter, request)
+            should_notify_upcoming_expiration(user, request)
         )
 
     def test_false_if_request_does_not_expire(self) -> None:
         """Verify the return value is `False` if the request does not expire."""
 
-        request = AllocationRequestFactory(expire=None)
-        PreferenceFactory(user=request.submitter, request_expiry_thresholds=[15])
+        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        request = AllocationRequestFactory(submitter=user, expire=None)
+        PreferenceFactory(user=user, request_expiry_thresholds=[15])
 
         self.assertFalse(
-            should_notify_upcoming_expiration(request.submitter, request)
+            should_notify_upcoming_expiration(user, request)
         )
 
     def test_false_if_request_already_expired(self) -> None:
         """Verify the return value is `False` if the request has already expired."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, request_expiry_thresholds=[15])
+        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        request = AllocationRequestFactory(submitter=user, expire=date.today())
+        PreferenceFactory(user=user, request_expiry_thresholds=[15])
 
         self.assertFalse(
-            should_notify_upcoming_expiration(request.submitter, request)
+            should_notify_upcoming_expiration(user, request)
         )
 
     def test_false_if_no_threshold_reached(self) -> None:
         """Verify the return value is `False` if no threshold has been reached."""
 
-        request = AllocationRequestFactory(expire=date.today() + timedelta(days=15))
-        PreferenceFactory(user=request.submitter, request_expiry_thresholds=[5])
+        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        request = AllocationRequestFactory(submitter=user, expire=date.today() + timedelta(days=15))
+        PreferenceFactory(user=user, request_expiry_thresholds=[5])
 
         self.assertFalse(
-            should_notify_upcoming_expiration(request.submitter, request)
+            should_notify_upcoming_expiration(user, request)
         )
 
     def test_false_if_user_recently_joined(self) -> None:


### PR DESCRIPTION
The `UserFactory` assigns a randomized `date_joined` value. This field is referenced in `should_notify_upcoming_expiration` to prevent sending expiration notifications for periods before a user’s account existed.

Because the join date was not controlled in tests, the notification check could evaluate differently across runs, leading to intermittent test failures.

This change fixes the issue by explicitly setting a deterministic `date_joined` in tests, ensuring stable and reproducible outcomes.
