### PR TITLE
Use docker/build-push-action to publish to CloudSmith

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
-          images: ghcr.io/better-hpc/keystone-api
+          images: docker.cloudsmith.io/better-hpc/keystone-api
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
@@ -58,7 +58,7 @@ jobs:
             org.opencontainers.image.authors="Better HPC LLC"
             org.opencontainers.image.revision="${{ github.sha }}"
             org.opencontainers.image.vendor="Better HPC LLC"
-            org.opencontainers.image.ref.name="ghcr.io/better-hpc/keystone-api:${{ inputs.version }}"
+            org.opencontainers.image.ref.name="docker.cloudsmith.io/better-hpc/keystone-api:${{ inputs.version }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -66,34 +66,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to container registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.cloudsmith.io
+          username: ${{ secrets.CLOUDSMITH_USERNAME }}
+          password: ${{ secrets.CLOUDSMITH_API_KEY  }}
 
-      - name: Build image with multi-arch support
+      - name: Publish image
         uses: docker/build-push-action@v6
         with:
           context: .
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64,linux/arm64
-          outputs: type=docker,dest=/tmp/publish.tar
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Publish image
-        uses: cloudsmith-io/action@master
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "docker"
-          owner: "better-hpc"
-          repo: "keystone"
-          file: "/tmp/publish.tar"
 
   publish-python:
     name: Python Distribution


### PR DESCRIPTION
Progress on migration from GHCR to CloudSmith