### PR TITLE
Trims down docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
 
 # Install application wheels
 COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir /wheels/* && rm -rf /wheels
+RUN pip install --no-compile --no-cache-dir /wheels/* && rm -rf /wheels
 
 # Create unprivileged users/directories for running services
 RUN addgroup -g 121 keystone \


### PR DESCRIPTION
Disabling pip compilation on install drops the image size from 267MB to 229MB (38MB savings).