### PR TITLE
Makes team slug readonly in admin interface

### DIFF
--- a/keystone_api/apps/users/admin.py
+++ b/keystone_api/apps/users/admin.py
@@ -119,4 +119,5 @@ class TeamAdmin(admin.ModelAdmin):
     list_display = ('name', 'is_active', 'total_members', 'owners')
     search_fields = ('name',)
     list_filter = ('is_active',)
+    readonly_fields = ('slug',)
     inlines = [MembershipInline]


### PR DESCRIPTION
The slug value is set dynamically by the model and should not be user editable.