### PR TITLE
Adds `funding_upcoming` and `upcoming_count` values to grant stats

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -9374,27 +9374,22 @@ components:
           type: string
           format: decimal
           pattern: ^-?\d{0,15}(?:\.\d{0,2})?$
-          nullable: true
         funding_upcoming:
           type: string
           format: decimal
           pattern: ^-?\d{0,15}(?:\.\d{0,2})?$
-          nullable: true
         funding_active:
           type: string
           format: decimal
           pattern: ^-?\d{0,15}(?:\.\d{0,2})?$
-          nullable: true
         funding_expired:
           type: string
           format: decimal
           pattern: ^-?\d{0,15}(?:\.\d{0,2})?$
-          nullable: true
         funding_average:
           type: string
           format: decimal
           pattern: ^-?\d{0,15}(?:\.\d{0,2})?$
-          nullable: true
       required:
       - active_count
       - agency_count

--- a/keystone_api/apps/stats/serializers.py
+++ b/keystone_api/apps/stats/serializers.py
@@ -60,11 +60,11 @@ class GrantStatsSerializer(serializers.Serializer):
     expired_count = serializers.IntegerField()
     agency_count = serializers.IntegerField()
 
-    funding_total = serializers.DecimalField(max_digits=17, decimal_places=2, allow_null=True)
-    funding_upcoming = serializers.DecimalField(max_digits=17, decimal_places=2, allow_null=True)
-    funding_active = serializers.DecimalField(max_digits=17, decimal_places=2, allow_null=True)
-    funding_expired = serializers.DecimalField(max_digits=17, decimal_places=2, allow_null=True)
-    funding_average = serializers.DecimalField(max_digits=17, decimal_places=2, allow_null=True)
+    funding_total = serializers.DecimalField(max_digits=17, decimal_places=2)
+    funding_upcoming = serializers.DecimalField(max_digits=17, decimal_places=2)
+    funding_active = serializers.DecimalField(max_digits=17, decimal_places=2)
+    funding_expired = serializers.DecimalField(max_digits=17, decimal_places=2)
+    funding_average = serializers.DecimalField(max_digits=17, decimal_places=2)
 
 
 class PublicationStatsSerializer(serializers.Serializer):

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(BASE_DIR))
 dist = importlib.metadata.distribution('keystone-api')
 VERSION = dist.metadata['version']
 SUMMARY = dist.metadata['summary']
-
+DEBUG=True
 env = environ.Env()
 
 # Core security settings


### PR DESCRIPTION
Also updates the response to ensure funding totals and averages default to `0` instead of a confusing `null` when no records are present. This simplifies the implementation of fronted logic.