### PR TITLE
Whitelist application specific headers in CORS settings

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -55,6 +55,15 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_SUBDOMAINS", False)
 
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=_trusted_local)
+CORS_ALLOW_HEADERS = [
+    "accept",
+    "authorization",
+    "content-type",
+    "user-agent",
+    "x-csrftoken",
+    "x-requested-with",
+    "x-keystone-cid",
+]
 
 ALLOWED_FILE_TYPES = [
     # Documents


### PR DESCRIPTION
The application CID header was missing from the default `CORS_ALLOW_HEADERS` list. This PR explicitly configures the `CORS_ALLOW_HEADERS` to include application specific headers.