### PR TITLE
Renames DEBUG_EMAIL_DIR setting to EMAIL_DEBUG_DIR

### DIFF
--- a/docs/setup/settings.md
+++ b/docs/setup/settings.md
@@ -136,6 +136,7 @@ Securing your production email server with a username/password is strongly recom
 | `EMAIL_USE_TLS`       | `False`                   | Use a TLS connection to the SMTP server.                |
 | `EMAIL_FROM_ADDRESS`  | `noreply@keystone.bot`    | The default "from" address used in email notifications. |
 | `EMAIL_TEMPLATE_DIR`  | `/etc/keystone/templates` | Directory to search for customized email templates.     |
+| `EMAIL_DEBUG_DIR`     |                           | Write emails to disk instead of using the SMTP server.  |
 
 ## LDAP Authentication
 
@@ -164,11 +165,3 @@ See the `apps.users.models.User` class for a full list of available Keystone fie
 | `AUTH_LDAP_ATTR_MAP`      |                  | A mapping of user fields to LDAP attribute names.                 |
 | `AUTH_LDAP_PURGE_REMOVED` | `False`          | Delete users when removed from LDAP instead of deactivating them. |
 | `AUTH_LDAP_TIMEOUT`       | `10`             | The number of seconds before timing out an LDAP connection/query. |
-
-## Developer Settings
-
-The following settings are intended for use in debugging or development.
-
-| Setting Name      | Default Value | Description                                            |
-|-------------------|---------------|--------------------------------------------------------|
-| `DEBUG_EMAIL_DIR` |               | Write emails to disk instead of using the SMTP server. |

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -270,7 +270,7 @@ EMAIL_FROM_ADDRESS = env.str('EMAIL_FROM_ADDRESS', 'noreply@keystone.bot')
 EMAIL_TEMPLATE_DIR = Path(env.path('EMAIL_TEMPLATE_DIR', '/etc/keystone/templates'))
 EMAIL_DEFAULT_DIR = BASE_DIR / 'templates'
 
-if _email_path := env.get_value('DEBUG_EMAIL_DIR', default=None):
+if _email_path := env.get_value('EMAIL_DEBUG_DIR', default=None):
     EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
     EMAIL_FILE_PATH = _email_path
 


### PR DESCRIPTION
Renames the `DEBUG_EMAIL_DIR` setting to `EMAIL_DEBUG_DIR` so the standard `[category]_[setting name]` naming system groups it with the email settings group instead of the (non-existent) debug settings group.