### PR TITLE
Fixes bug when parsing `EMAIL_HOST_PASSWORD` and `AUTH_LDAP_REQUIRE_CERT` settings

### DIFF
--- a/docs/setup/settings.md
+++ b/docs/setup/settings.md
@@ -36,28 +36,17 @@ When using a reverse proxy for TLS, the settings below can be left at their defa
 | `SECURE_HSTS_SUBDOMAINS` | `False`        | Enable HSTS for subdomains.                       |
 | `SECURE_HSTS_PRELOAD`    | `False`        | Enable HSTS preload functionality.                |
 
-### CORS/CSRF
+### Auth Tokens
 
-CORS and CSRF settings define which domains are allowed to interact with the Keystone-API.
+The following settings define which domains are allowed to interact with the Keystone-API.
 In most deployments, these settings should be configured as follows:
 
-- **`SECURE_ALLOWED_HOSTS`**: Set to the domain name(s) where the API is hosted (e.g., `api.example.com`).
-- **`SECURE_ALLOWED_ORIGINS`** and **`SECURE_CSRF_ORIGINS`**: Set to the full URL(s) of the frontend web application (
-  e.g., `https://app.example.com`).
-- **`SECURE_SSL_TOKENS`**: Set to `True` when serving over HTTPS to ensure tokens are only transmitted over secure
-  connections.
+- **`SECURE_SSL_TOKENS`**: Enabled when serving over HTTPS and disabled otherwise.
+- **`SECURE_ALLOWED_HOSTS`**: Set to the domain name(s) where the API is hosted <br> (e.g., `api.example.com`).
+- **`SECURE_ALLOWED_ORIGINS`**: Set to the full URL(s) of the frontend web application <br> (e.g., `https://app.example.com`).
 - **`SECURE_TOKEN_DOMAIN`**: Only required when the API and frontend are hosted on different subdomains of the same
-  parent domain. Set to the parent domain with a leading dot (e.g., `.example.com`) to allow token sharing across
-  subdomains.
-
-| Setting Name             | Default Value                        <br/><br/> | Description                                                                                      |
-|--------------------------|-------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| `SECURE_ALLOWED_HOSTS`   | <code>localhost,127.0.0.1</code>                | Comma-separated list of api host/domain names (**without** protocol).                            |
-| `SECURE_ALLOWED_ORIGINS` | _See default local addresses._                  | Comma-separated list of accepted CORS origin domains (**with** protocol).                        |
-| `SECURE_CSRF_ORIGINS`    | _See default local addresses._                  | Comma-separated list of accepted CSRF origin domains (**with** protocol).                        |
-| `SECURE_SSL_TOKENS`      | `False`                                         | Only issue session/CSRF tokens over secure connections.                                          |
-| `SECURE_SESSION_AGE`     | `1209600` (2 weeks)                             | Number of seconds before session tokens expire.                                                  |
-| `SECURE_TOKEN_DOMAIN`    | None                                            | Domain attribute for session/csrf cookies. Set for cross-subdomain usage (e.g., `.example.com`). | 
+  parent domain. This setting should specify the parent domain with a leading dot (e.g., `.example.com`) to allow 
+  token sharing across subdomains.
 
 Default values are defined relative to the following list of _default local addresses_:
 
@@ -69,6 +58,14 @@ Default values are defined relative to the following list of _default local addr
 - `https://127.0.0.1:443`
 - `http://127.0.0.1:4200`
 - `http://127.0.0.1:8000`
+
+| Setting Name             | Default Value                        <br/><br/> | Description                                                                                      |
+|--------------------------|-------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `SECURE_SSL_TOKENS`      | `False`                                         | Only issue session/CSRF tokens over secure connections.                                          |
+| `SECURE_ALLOWED_HOSTS`   | <code>localhost,127.0.0.1</code>                | Comma-separated list of api host/domain names (**without** protocol).                            |
+| `SECURE_ALLOWED_ORIGINS` | _See default local addresses._                  | Comma-separated list of accepted client origin domains (**with** protocol).                      |
+| `SECURE_SESSION_AGE`     | `1209600` (2 weeks)                             | Number of seconds before session tokens expire.                                                  |
+| `SECURE_TOKEN_DOMAIN`    | None                                            | Domain attribute for session/csrf cookies. Set for cross-subdomain usage (e.g., `.example.com`). |
 
 ## General Configuration
 
@@ -86,8 +83,7 @@ By default, these files are stored in subdirectories of the installed applicatio
 ## Logging
 
 Keystone automatically purges log records according to the policy settings below.
-Application logs are written to disk using a size-based policy that rotates files according to a maximum file
-size/count.
+Application logs are written to disk using a size-based policy that rotates files according to a maximum file size/count.
 Audit, request, and task logs are maintained in the application database and are removed once they exceed a configured
 age (in seconds).
 

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -43,22 +43,14 @@ SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_AGE = env.int("SECURE_SESSION_AGE", timedelta(days=14).total_seconds())
 
-CSRF_TRUSTED_ORIGINS = env.list("SECURE_CSRF_ORIGINS", default=_trusted_local)
-CSRF_COOKIE_SECURE = _SECURE_SSL_TOKENS
-CSRF_COOKIE_HTTPONLY = False
-CSRF_COOKIE_SAMESITE = "Lax"
-
-_cookie_domain = os.environ.get("SECURE_TOKEN_DOMAIN", None)
-SESSION_COOKIE_DOMAIN = _cookie_domain
-CSRF_COOKIE_DOMAIN = _cookie_domain
-
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", False)
 SECURE_HSTS_PRELOAD = env.bool("SECURE_HSTS_PRELOAD", False)
 SECURE_HSTS_SECONDS = env.int("SECURE_HSTS_SECONDS", 0)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_SUBDOMAINS", False)
 
+_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=_trusted_local)
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOWED_ORIGINS = env.list("SECURE_ALLOWED_ORIGINS", default=_trusted_local)
+CORS_ALLOWED_ORIGINS = _ALLOWED_ORIGINS
 CORS_ALLOW_HEADERS = [
     "accept",
     "authorization",
@@ -68,6 +60,15 @@ CORS_ALLOW_HEADERS = [
     "x-requested-with",
     "x-keystone-cid",
 ]
+
+CSRF_TRUSTED_ORIGINS = _ALLOWED_ORIGINS
+CSRF_COOKIE_SECURE = _SECURE_SSL_TOKENS
+CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_SAMESITE = "Lax"
+
+_cookie_domain = os.environ.get("SECURE_TOKEN_DOMAIN", None)
+SESSION_COOKIE_DOMAIN = _cookie_domain
+CSRF_COOKIE_DOMAIN = _cookie_domain
 
 ALLOWED_FILE_TYPES = [
     # Documents


### PR DESCRIPTION
Fixes bugs where the `EMAIL_HOST_PASSWORD` setting is parsed from the wrong environmental variable and `AUTH_LDAP_REQUIRE_CERT` parses the inverse of the provided boolean.

The `SECURE_CSRF_ORIGINS` setting has also been removed and is now pinned to the same value as `SECURE_ALLOWED_ORIGINS`