### PR TITLE
Adds nested _attachments field to allocation requests

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -12035,6 +12035,12 @@ components:
             $ref: '#/components/schemas/AllocationSummary'
           readOnly: true
           title: ' allocations'
+        _attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllocationSummary'
+          readOnly: true
+          title: ' attachments'
         _comments:
           type: array
           items:
@@ -12081,6 +12087,7 @@ components:
       required:
       - _allocations
       - _assignees
+      - _attachments
       - _comments
       - _grants
       - _history
@@ -12144,6 +12151,12 @@ components:
             $ref: '#/components/schemas/AllocationSummary'
           readOnly: true
           title: ' allocations'
+        _attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllocationSummary'
+          readOnly: true
+          title: ' attachments'
         _comments:
           type: array
           items:
@@ -12201,6 +12214,7 @@ components:
       required:
       - _allocations
       - _assignees
+      - _attachments
       - _comments
       - _grants
       - _history
@@ -13528,6 +13542,12 @@ components:
             $ref: '#/components/schemas/AllocationSummary'
           readOnly: true
           title: ' allocations'
+        _attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllocationSummary'
+          readOnly: true
+          title: ' attachments'
         _comments:
           type: array
           items:

--- a/keystone_api/apps/allocations/serializers.py
+++ b/keystone_api/apps/allocations/serializers.py
@@ -46,6 +46,7 @@ class AllocationRequestSerializer(serializers.ModelSerializer):
     _grants = GrantSummarySerializer(source='grants', many=True, read_only=True)
     _history = AuditLogSummarySerializer(source='history', many=True, read_only=True)
     _allocations = AllocationSummarySerializer(source='allocation_set', many=True, read_only=True)
+    _attachments = AllocationSummarySerializer(source='attachment_set', many=True, read_only=True)
     _comments = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
Includes file attachment metadata when returning alocation request records to users. This simplifies displaying the request on end user pages.