### PR TITLE
Adds missing serializer for nesting file attachments

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -12038,7 +12038,7 @@ components:
         _attachments:
           type: array
           items:
-            $ref: '#/components/schemas/AllocationSummary'
+            $ref: '#/components/schemas/AttachmentSummary'
           readOnly: true
           title: ' attachments'
         _comments:
@@ -12154,7 +12154,7 @@ components:
         _attachments:
           type: array
           items:
-            $ref: '#/components/schemas/AllocationSummary'
+            $ref: '#/components/schemas/AttachmentSummary'
           readOnly: true
           title: ' attachments'
         _comments:
@@ -12459,6 +12459,16 @@ components:
       - id
       - request
       - uploaded
+    AttachmentSummary:
+      type: object
+      description: Serializer for summarizing file attachments in nested responses.
+      properties:
+        file:
+          type: string
+        name:
+          type: string
+      required:
+      - file
     AuditLog:
       type: object
       description: Object serializer for the `AuditLog` class.
@@ -13545,7 +13555,7 @@ components:
         _attachments:
           type: array
           items:
-            $ref: '#/components/schemas/AllocationSummary'
+            $ref: '#/components/schemas/AttachmentSummary'
           readOnly: true
           title: ' attachments'
         _comments:

--- a/keystone_api/apps/allocations/nested.py
+++ b/keystone_api/apps/allocations/nested.py
@@ -16,6 +16,7 @@ __all__ = [
     'AllocationRequestSummarySerializer',
     'AllocationInlineSerializer',
     'AllocationSummarySerializer',
+    'AttachmentSummarySerializer',
     'ClusterSummarySerializer',
     'CommentSummarySerializer',
 ]
@@ -58,6 +59,19 @@ class AllocationSummarySerializer(serializers.ModelSerializer):
     class Meta:
         model = Allocation
         fields = ['id', 'cluster', 'requested', 'awarded', 'final', '_cluster']
+
+
+class AttachmentSummarySerializer(serializers.ModelSerializer):
+    """Serializer for summarizing file attachments in nested responses."""
+
+    file = serializers.FileField(use_url=False)
+    name = serializers.CharField(required=False)
+
+    class Meta:
+        """Serializer settings."""
+
+        model = Attachment
+        fields = ['file', 'name']
 
 
 class CommentSummarySerializer(serializers.ModelSerializer):

--- a/keystone_api/apps/allocations/serializers.py
+++ b/keystone_api/apps/allocations/serializers.py
@@ -46,7 +46,7 @@ class AllocationRequestSerializer(serializers.ModelSerializer):
     _grants = GrantSummarySerializer(source='grants', many=True, read_only=True)
     _history = AuditLogSummarySerializer(source='history', many=True, read_only=True)
     _allocations = AllocationSummarySerializer(source='allocation_set', many=True, read_only=True)
-    _attachments = AllocationSummarySerializer(source='attachment_set', many=True, read_only=True)
+    _attachments = AttachmentSummarySerializer(source='attachment_set', many=True, read_only=True)
     _comments = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
Looks like I made a mistake in PR #808 and forgot to include an implementation for the`AttachmentSummarySerializer` class. I've made an internal note to eventually add end-to-end tests which would catch this kind of issue.