### PR TITLE
Requires submitter field when creation allocation requests

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -12097,6 +12097,7 @@ components:
       - description
       - id
       - submitted
+      - submitter
       - team
       - title
     AllocationRequestCreate:
@@ -12224,6 +12225,7 @@ components:
       - description
       - id
       - submitted
+      - submitter
       - team
       - title
     AllocationRequestStats:

--- a/keystone_api/apps/allocations/serializers.py
+++ b/keystone_api/apps/allocations/serializers.py
@@ -55,6 +55,7 @@ class AllocationRequestSerializer(serializers.ModelSerializer):
         model = AllocationRequest
         fields = '__all__'
         extra_kwargs = {
+            'submitter': {'required': True},
             'submitted': {'read_only': True},
         }
 

--- a/keystone_api/tests/function_tests/allocations/test_request_detail.py
+++ b/keystone_api/tests/function_tests/allocations/test_request_detail.py
@@ -126,7 +126,12 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         """Verify staff users have full read and write permissions."""
 
         self.client.force_authenticate(user=self.staff_user)
-        record_data = {'title': 'foo', 'description': 'bar', 'team': self.team.pk}
+        record_data = {
+            'title': 'foo',
+            'description': 'bar',
+            'team': self.team.pk,
+            'submitter': self.staff_user.id
+        }
 
         self.assert_http_responses(
             self.endpoint,

--- a/keystone_api/tests/function_tests/allocations/test_request_list.py
+++ b/keystone_api/tests/function_tests/allocations/test_request_list.py
@@ -43,7 +43,12 @@ class EndpointPermissions(APITestCase, CustomAsserts):
         self.non_member = UserFactory()
         self.staff_user = UserFactory(is_staff=True)
 
-        self.valid_record_data = {'title': 'foo', 'description': 'bar', 'team': self.team.pk}
+        self.valid_record_data = {
+            'title': 'foo',
+            'description': 'bar',
+            'team': self.team.pk,
+            'submitter': self.non_member.id
+        }
 
     def test_anonymous_user_permissions(self) -> None:
         """Verify unauthenticated users cannot access resources."""


### PR DESCRIPTION
Makes the submitter field required when submitting allocation requests.