### PR TITLE
Require at least one allocation by default when seeding data

### DIFF
--- a/keystone_api/apps/admin_utils/management/commands/genseeddata.py
+++ b/keystone_api/apps/admin_utils/management/commands/genseeddata.py
@@ -60,7 +60,7 @@ class Command(StdOutUtils, BaseCommand):
         parser.add_argument('--n-team-grants', **range_options, help='Min/max grants to create per team.', default=[4, 8])
         parser.add_argument('--n-team-pubs', **range_options, help='Min/max publications to create per team.', default=[4, 8])
         parser.add_argument('--n-team-reqs', **range_options, help='Min/max allocation requests to create per team.', default=[4, 8])
-        parser.add_argument('--n-req-clusters', **range_options, help='Min/max clusters to include per request.', default=[0, 5])
+        parser.add_argument('--n-req-clusters', **range_options, help='Min/max clusters to include per request.', default=[1, 5])
         parser.add_argument('--n-req-jobs', **range_options, help='Min/max Slurm jobs to create per request.', default=[0, 30])
         parser.add_argument('--n-req-grants', **range_options, help='Min/max grants to attach to each request.', default=[1, 2])
         parser.add_argument('--n-req-pubs', **range_options, help='Min/max publications to attach to each request.', default=[1, 2])


### PR DESCRIPTION
The `--n-req-clusters` option of the `genseedata` command currently defaults to the range `[0, 5]` (inclusive), meaning an allocation request is allowed to have zero associated allocations when generating mock data. This PR increases the minimum value to 1, ensuring requests always have at least one allocation when beta testing frontend components.