### PR TITLE
Fixes random date bug in notification task testing

### DIFF
--- a/keystone_api/tests/unit_tests/apps/notifications/tasks/test_past_expirations.py
+++ b/keystone_api/tests/unit_tests/apps/notifications/tasks/test_past_expirations.py
@@ -86,12 +86,19 @@ class ShouldNotifyPastExpirationMethod(TestCase):
 class SendPastExpirationNoticeContext(TestCase):
     """Test the template context passed by the past expiration notification task."""
 
+    def setUp(self) -> None:
+        """Create a mock allocation request that expires today."""
+
+        self.request = AllocationRequestFactory(
+            active=date.today() - timedelta(days=5),
+            expire=date.today()
+        )
+
     def test_context_contains_all_required_keys(self, mock_send: Mock) -> None:
         """Verify the context dictionary includes all keys expected by the template."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         mock_send.assert_called_once()
         context = mock_send.call_args.kwargs['context']
@@ -100,36 +107,33 @@ class SendPastExpirationNoticeContext(TestCase):
     def test_context_user_fields_match_user(self, mock_send: Mock) -> None:
         """Verify user-related context values match the notified user."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
-        self.assertEqual(context['user_name'], request.submitter.username)
-        self.assertEqual(context['user_first'], request.submitter.first_name)
-        self.assertEqual(context['user_last'], request.submitter.last_name)
+        self.assertEqual(context['user_name'], self.request.submitter.username)
+        self.assertEqual(context['user_first'], self.request.submitter.first_name)
+        self.assertEqual(context['user_last'], self.request.submitter.last_name)
 
     def test_context_request_fields_match_request(self, mock_send: Mock) -> None:
         """Verify request-related context values match the expired allocation request."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
-        self.assertEqual(context['req_id'], request.id)
-        self.assertEqual(context['req_title'], request.title)
-        self.assertEqual(context['req_team'], request.team.name)
-        self.assertEqual(context['req_submitted'], request.submitted)
-        self.assertEqual(context['req_active'], request.active)
-        self.assertEqual(context['req_expire'], request.expire)
+        self.assertEqual(context['req_id'], self.request.id)
+        self.assertEqual(context['req_title'], self.request.title)
+        self.assertEqual(context['req_team'], self.request.team.name)
+        self.assertEqual(context['req_submitted'], self.request.submitted)
+        self.assertEqual(context['req_active'], self.request.active)
+        self.assertEqual(context['req_expire'], self.request.expire)
 
     def test_context_allocations_are_populated(self, mock_send: Mock) -> None:
         """Verify the allocations list is a non-empty tuple with expected keys."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         self.assertIsInstance(context['allocations'], tuple)
@@ -142,9 +146,8 @@ class SendPastExpirationNoticeContext(TestCase):
     def test_context_upcoming_requests_have_expected_keys(self, mock_send: Mock) -> None:
         """Verify upcoming request entries contain the expected keys."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         self.assertIsInstance(context['upcoming_requests'], tuple)
@@ -159,26 +162,25 @@ class SendPastExpirationNoticeContext(TestCase):
     def test_notification_metadata_includes_request_id(self, mock_send: Mock) -> None:
         """Verify the notification metadata includes the allocation request ID."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         metadata = mock_send.call_args.kwargs['notification_metadata']
-        self.assertEqual(metadata['request_id'], request.id)
+        self.assertEqual(metadata['request_id'], self.request.id)
 
     def test_subject_includes_request_id(self, mock_send: Mock) -> None:
         """Verify the email subject line includes the allocation request ID."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         subject = mock_send.call_args.kwargs['subject']
-        self.assertIn(str(request.id), subject)
+        self.assertIn(str(self.request.id), subject)
 
     def test_not_called_when_should_notify_is_false(self, mock_send: Mock) -> None:
         """Verify the notification is not sent when the user should not be notified."""
 
+        # Request has not expired and user has enabled notifications
         request = AllocationRequestFactory(expire=date.today() + timedelta(days=5))
         PreferenceFactory(user=request.submitter, notify_on_expiration=True)
         send_past_expiration_notice(request.submitter.id, request.id)
@@ -188,9 +190,8 @@ class SendPastExpirationNoticeContext(TestCase):
     def test_context_renders_default_template(self, mock_send: Mock) -> None:
         """Verify the task context renders the default template without undefined variable errors."""
 
-        request = AllocationRequestFactory(expire=date.today())
-        PreferenceFactory(user=request.submitter, notify_on_expiration=True)
-        send_past_expiration_notice(request.submitter.id, request.id)
+        PreferenceFactory(user=self.request.submitter, notify_on_expiration=True)
+        send_past_expiration_notice(self.request.submitter.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         template = get_template('past_expiration.html')

--- a/keystone_api/tests/unit_tests/apps/notifications/tasks/test_upcoming_expirations.py
+++ b/keystone_api/tests/unit_tests/apps/notifications/tasks/test_upcoming_expirations.py
@@ -137,19 +137,20 @@ class ShouldNotifyUpcomingExpirationMethod(TestCase):
 class SendUpcomingExpirationNoticeContext(TestCase):
     """Test the template context passed by the upcoming expiration notification task."""
 
-    def test_context_renders_default_template(self, mock_send: Mock) -> None:
-        """Verify the task context renders the default template without undefined variable errors."""
-
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
+    def setUp(self) -> None:
+        self.user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        self.request = AllocationRequestFactory(
+            submitter=self.user,
             submitted=timezone.now() - timedelta(days=30),
             active=date.today() - timedelta(days=30),
             expire=date.today() + timedelta(days=5),
         )
 
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+    def test_context_renders_default_template(self, mock_send: Mock) -> None:
+        """Verify the task context renders the default template without undefined variable errors."""
+
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         template = get_template('upcoming_expiration.html')
@@ -184,38 +185,22 @@ class SendUpcomingExpirationNoticeContext(TestCase):
     def test_context_request_fields_match_request(self, mock_send: None) -> None:
         """Verify request-related context values match the expiring allocation request."""
 
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
-            submitted=timezone.now() - timedelta(days=30),
-            active=date.today() - timedelta(days=30),
-            expire=date.today() + timedelta(days=5),
-        )
-
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
-        self.assertEqual(context['req_id'], request.id)
-        self.assertEqual(context['req_title'], request.title)
-        self.assertEqual(context['req_team'], request.team.name)
-        self.assertEqual(context['req_submitted'], request.submitted)
-        self.assertEqual(context['req_active'], request.active)
-        self.assertEqual(context['req_expire'], request.expire)
+        self.assertEqual(context['req_id'], self.request.id)
+        self.assertEqual(context['req_title'], self.request.title)
+        self.assertEqual(context['req_team'], self.request.team.name)
+        self.assertEqual(context['req_submitted'], self.request.submitted)
+        self.assertEqual(context['req_active'], self.request.active)
+        self.assertEqual(context['req_expire'], self.request.expire)
 
     def test_context_days_left_is_correct(self, mock_send: None) -> None:
         """Verify the days remaining until expiration is calculated correctly."""
 
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
-            submitted=timezone.now() - timedelta(days=30),
-            active=date.today() - timedelta(days=30),
-            expire=date.today() + timedelta(days=5),
-        )
-
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         self.assertEqual(context['req_days_left'], 5)
@@ -223,16 +208,8 @@ class SendUpcomingExpirationNoticeContext(TestCase):
     def test_context_allocations_are_populated(self, mock_send: None) -> None:
         """Verify the allocations list is a non-empty tuple with expected keys."""
 
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
-            submitted=timezone.now() - timedelta(days=30),
-            active=date.today() - timedelta(days=30),
-            expire=date.today() + timedelta(days=5),
-        )
-
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         self.assertIsInstance(context['allocations'], tuple)
@@ -244,16 +221,8 @@ class SendUpcomingExpirationNoticeContext(TestCase):
     def test_context_upcoming_requests_have_expected_keys(self, mock_send: None) -> None:
         """Verify upcoming request entries contain the expected keys."""
 
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
-            submitted=timezone.now() - timedelta(days=30),
-            active=date.today() - timedelta(days=30),
-            expire=date.today() + timedelta(days=5),
-        )
-
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         context = mock_send.call_args.kwargs['context']
         self.assertIsInstance(context['upcoming_requests'], tuple)
@@ -268,42 +237,29 @@ class SendUpcomingExpirationNoticeContext(TestCase):
     def test_notification_metadata_includes_request_id_and_days(self, mock_send: None) -> None:
         """Verify the notification metadata includes the request ID and days to expiration."""
 
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
-            submitted=timezone.now() - timedelta(days=30),
-            active=date.today() - timedelta(days=30),
-            expire=date.today() + timedelta(days=5),
-        )
-
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         metadata = mock_send.call_args.kwargs['notification_metadata']
-        self.assertEqual(metadata['request_id'], request.id)
+        self.assertEqual(metadata['request_id'], self.request.id)
         self.assertEqual(metadata['days_to_expire'], 5)
 
     def test_subject_includes_request_id(self, mock_send: None) -> None:
         """Verify the email subject line includes the allocation request ID."""
 
-        user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
-        request = AllocationRequestFactory(
-            submitter=user,
-            submitted=timezone.now() - timedelta(days=30),
-            active=date.today() - timedelta(days=30),
-            expire=date.today() + timedelta(days=5),
-        )
-
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
-        send_upcoming_expiration_notice(user.id, request.id)
+        PreferenceFactory(user=self.user, request_expiry_thresholds=[5])
+        send_upcoming_expiration_notice(self.user.id, self.request.id)
 
         subject = mock_send.call_args.kwargs['subject']
-        self.assertIn(str(request.id), subject)
+        self.assertIn(str(self.request.id), subject)
 
     def test_not_called_when_should_notify_is_false(self, mock_send: None) -> None:
         """Verify the notification is not sent when the user should not be notified."""
 
+        # Create an allocation request that does not expire within the notification threshold
         user = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        PreferenceFactory(user=user, request_expiry_thresholds=[5])
+
         request = AllocationRequestFactory(
             submitter=user,
             submitted=timezone.now() - timedelta(days=30),
@@ -311,7 +267,5 @@ class SendUpcomingExpirationNoticeContext(TestCase):
             expire=date.today() + timedelta(days=15),
         )
 
-        PreferenceFactory(user=user, request_expiry_thresholds=[5])
         send_upcoming_expiration_notice(user.id, request.id)
-
         mock_send.assert_not_called()


### PR DESCRIPTION
Unit tests for some of the `notification.tasks.*` modules would sometimes fail due to mock allocation request objects randomly having `None` for their `active` date. This PR enforces a valid value in the tests ensuring the run accurately.